### PR TITLE
feat: add Anthropic direct API client

### DIFF
--- a/config/genai.php
+++ b/config/genai.php
@@ -5,8 +5,9 @@ return [
     |--------------------------------------------------------------------------
     | Default GenAI Provider
     |--------------------------------------------------------------------------
-    | "gemini"  — Google Gemini (generateContent + File API)
-    | "bedrock" — AWS Bedrock Converse API (Claude models)
+    | "gemini"    — Google Gemini (generateContent + File API)
+    | "bedrock"   — AWS Bedrock Converse API (Claude models)
+    | "anthropic" — Anthropic Messages API (direct, not via Bedrock)
     */
     'default' => env('GENAI_PROVIDER', 'gemini'),
 
@@ -27,6 +28,25 @@ return [
 
             // HTTP timeout in seconds for long-running inference calls.
             'timeout' => (int) env('GEMINI_TIMEOUT', 240),
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Anthropic Messages API (direct)
+        |--------------------------------------------------------------------------
+        */
+        'anthropic' => [
+            // API key from https://console.anthropic.com/
+            'api_key' => env('ANTHROPIC_API_KEY'),
+
+            // Model ID. See https://docs.anthropic.com/en/docs/about-claude/models
+            'model' => env('ANTHROPIC_MODEL', 'claude-sonnet-4-6'),
+
+            // Maximum tokens in the response.
+            'max_tokens' => (int) env('ANTHROPIC_MAX_TOKENS', 8192),
+
+            // HTTP timeout in seconds for long-running inference calls.
+            'timeout' => (int) env('ANTHROPIC_TIMEOUT', 240),
         ],
 
         /*

--- a/src/Clients/AnthropicClient.php
+++ b/src/Clients/AnthropicClient.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Clients;
+
+use Bherila\GenAiLaravel\Contracts\GenAiClient;
+use Bherila\GenAiLaravel\Exceptions\GenAiException;
+use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
+use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Anthropic Messages API implementation of GenAiClient.
+ *
+ * Uses the direct Anthropic API (api.anthropic.com), not AWS Bedrock.
+ * Files must be embedded as base64 inline content blocks — there is no
+ * persistent File API. Use converseWithInlineFile() to send documents.
+ *
+ * Config keys (all under genai.providers.anthropic):
+ *   api_key    — Anthropic API key
+ *   model      — e.g. "claude-sonnet-4-6" (default: "claude-sonnet-4-6")
+ *   max_tokens — maximum output tokens (default: 8192)
+ *   timeout    — HTTP timeout in seconds (default: 240)
+ */
+class AnthropicClient implements GenAiClient
+{
+    private const API_BASE = 'https://api.anthropic.com';
+
+    private const API_VERSION = '2023-06-01';
+
+    private string $model;
+
+    private int $maxTokens;
+
+    private \Illuminate\Http\Client\PendingRequest $http;
+
+    public function __construct(
+        string $apiKey,
+        string $model = 'claude-sonnet-4-6',
+        int $maxTokens = 8192,
+        int $timeout = 240,
+    ) {
+        $this->model = $model;
+        $this->maxTokens = $maxTokens;
+        $this->http = Http::withHeaders([
+            'x-api-key' => $apiKey,
+            'anthropic-version' => self::API_VERSION,
+            'Content-Type' => 'application/json',
+        ])->timeout($timeout);
+    }
+
+    public function provider(): string
+    {
+        return 'anthropic';
+    }
+
+    /**
+     * Anthropic API limit per base64 document block.
+     * https://docs.anthropic.com/en/docs/build-with-claude/files
+     */
+    public static function maxFileBytes(): int
+    {
+        return 4_718_592; // 4.5 MB
+    }
+
+    /**
+     * Anthropic direct API has no persistent File API — always returns null.
+     * Use converseWithInlineFile() to send documents.
+     */
+    public function uploadFile(mixed $fileContent, string $mimeType, string $displayName = ''): ?string
+    {
+        return null;
+    }
+
+    /**
+     * No-op: Anthropic direct API does not store uploaded files.
+     */
+    public function deleteFile(string $fileRef): void {}
+
+    /**
+     * Not applicable for Anthropic direct API — use converseWithInlineFile() instead.
+     *
+     * @throws \LogicException
+     */
+    public function converseWithFileRef(string $fileRef, string $mimeType, string $prompt, ?array $toolConfig = null): array
+    {
+        throw new \LogicException('Anthropic direct API does not support file references. Use converseWithInlineFile() with base64-encoded bytes.');
+    }
+
+    /**
+     * Send a Messages API request with a single base64-encoded document block.
+     *
+     * @param  list<array{text: string}>  $system
+     * @param  array<string, mixed>|null  $toolConfig  Anthropic toolConfig shape: {tools: [...], tool_choice: {...}}.
+     * @return array<string, mixed>
+     */
+    public function converseWithInlineFile(string $fileBytes, string $mimeType, string $prompt, array $system = [], ?array $toolConfig = null): array
+    {
+        $messages = [[
+            'role' => 'user',
+            'content' => [
+                [
+                    'type' => 'document',
+                    'source' => [
+                        'type' => 'base64',
+                        'media_type' => $mimeType,
+                        'data' => $fileBytes,
+                    ],
+                ],
+                ['type' => 'text', 'text' => $prompt],
+            ],
+        ]];
+
+        return $this->converse($system, $messages, $toolConfig);
+    }
+
+    /**
+     * @param  list<array{text: string}>  $system
+     * @param  list<array{role: string, content: list<array<string, mixed>>}>  $messages  Anthropic-format content blocks.
+     * @param  array<string, mixed>|null  $toolConfig  Shape: {tools: [...], tool_choice: {...}}.
+     * @return array<string, mixed>
+     */
+    public function converse(array $system, array $messages, ?array $toolConfig = null): array
+    {
+        $payload = [
+            'model' => $this->model,
+            'max_tokens' => $this->maxTokens,
+            'messages' => $messages,
+        ];
+
+        if ($system !== []) {
+            $payload['system'] = array_map(
+                fn ($block) => ['type' => 'text', 'text' => $block['text'] ?? ''],
+                $system,
+            );
+        }
+
+        if ($toolConfig !== null && $toolConfig !== []) {
+            if (isset($toolConfig['tools'])) {
+                $payload['tools'] = $toolConfig['tools'];
+            }
+            if (isset($toolConfig['tool_choice'])) {
+                $payload['tool_choice'] = $toolConfig['tool_choice'];
+            }
+        }
+
+        $response = $this->http->post(self::API_BASE.'/v1/messages', $payload);
+
+        if (! $response->successful()) {
+            Log::error('Anthropic API request failed', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            if ($response->status() === 429) {
+                throw new GenAiRateLimitException('Anthropic API rate limit exceeded.');
+            }
+
+            if (in_array($response->status(), [400, 403, 404], true)) {
+                throw new GenAiFatalException('Anthropic API error: '.$response->body());
+            }
+
+            throw new GenAiException('Anthropic API error '.$response->status().': '.$response->body());
+        }
+
+        return $response->json() ?? [];
+    }
+
+    /**
+     * Extract text content from an Anthropic Messages API response.
+     *
+     * @param  array<string, mixed>  $response
+     */
+    public function extractText(array $response): string
+    {
+        $text = '';
+        foreach ($response['content'] ?? [] as $block) {
+            if (($block['type'] ?? '') === 'text' && is_string($block['text'] ?? null)) {
+                $text .= $block['text'];
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Extract tool_use blocks from an Anthropic Messages API response.
+     *
+     * @param  array<string, mixed>  $response
+     * @return list<array{name: string, input: array<string, mixed>}>
+     */
+    public function extractToolCalls(array $response): array
+    {
+        $calls = [];
+        foreach ($response['content'] ?? [] as $block) {
+            if (($block['type'] ?? '') !== 'tool_use') {
+                continue;
+            }
+            $calls[] = [
+                'name' => (string) ($block['name'] ?? ''),
+                'input' => is_array($block['input'] ?? null) ? $block['input'] : [],
+            ];
+        }
+
+        return $calls;
+    }
+}

--- a/src/Clients/GenAiClientFactory.php
+++ b/src/Clients/GenAiClientFactory.php
@@ -25,6 +25,7 @@ class GenAiClientFactory
         return match ($provider) {
             'gemini' => static::makeGemini(),
             'bedrock' => static::makeBedrock(),
+            'anthropic' => static::makeAnthropic(),
             default => throw new GenAiException("Unknown GenAI provider: {$provider}"),
         };
     }
@@ -59,6 +60,23 @@ class GenAiClientFactory
             modelId: $cfg['model'] ?? 'us.anthropic.claude-haiku-4-20250514-v1:0',
             region: $cfg['region'] ?? 'us-east-1',
             sessionToken: $cfg['session_token'] ?? '',
+        );
+    }
+
+    private static function makeAnthropic(): AnthropicClient
+    {
+        $cfg = config('genai.providers.anthropic', []);
+        $apiKey = $cfg['api_key'] ?? '';
+
+        if ($apiKey === '') {
+            throw new GenAiException('genai.providers.anthropic.api_key is not set.');
+        }
+
+        return new AnthropicClient(
+            apiKey: $apiKey,
+            model: $cfg['model'] ?? 'claude-sonnet-4-6',
+            maxTokens: (int) ($cfg['max_tokens'] ?? 8192),
+            timeout: (int) ($cfg['timeout'] ?? 240),
         );
     }
 }

--- a/src/Contracts/GenAiClient.php
+++ b/src/Contracts/GenAiClient.php
@@ -8,8 +8,8 @@ namespace Bherila\GenAiLaravel\Contracts;
  * Each method maps to the provider's native API in the most direct way possible.
  * Implementations handle authentication, retries, and error normalization internally.
  *
- * Supported providers: Google Gemini, AWS Bedrock (Anthropic Claude).
- * Future: Anthropic direct API, OpenAI.
+ * Supported providers: Google Gemini, AWS Bedrock (Anthropic Claude), Anthropic direct API.
+ * Future: OpenAI.
  */
 interface GenAiClient
 {

--- a/src/GenAiServiceProvider.php
+++ b/src/GenAiServiceProvider.php
@@ -18,6 +18,7 @@ class GenAiServiceProvider extends ServiceProvider
         // Named bindings for explicit provider selection in DI.
         $this->app->bind('genai.gemini', fn () => GenAiClientFactory::make('gemini'));
         $this->app->bind('genai.bedrock', fn () => GenAiClientFactory::make('bedrock'));
+        $this->app->bind('genai.anthropic', fn () => GenAiClientFactory::make('anthropic'));
     }
 
     public function boot(): void

--- a/tests/Unit/AnthropicClientTest.php
+++ b/tests/Unit/AnthropicClientTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Tests\Unit;
+
+use Bherila\GenAiLaravel\Clients\AnthropicClient;
+use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
+use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+
+class AnthropicClientTest extends TestCase
+{
+    private function makeClient(): AnthropicClient
+    {
+        return new AnthropicClient(
+            apiKey: 'test-key',
+            model: 'claude-sonnet-4-6',
+        );
+    }
+
+    private function fakeTextResponse(string $text = 'Hello!'): array
+    {
+        return [
+            'id' => 'msg_01abc',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [['type' => 'text', 'text' => $text]],
+            'model' => 'claude-sonnet-4-6',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ];
+    }
+
+    // ── provider / static ────────────────────────────────────────────────────
+
+    public function test_provider_returns_anthropic(): void
+    {
+        $this->assertSame('anthropic', $this->makeClient()->provider());
+    }
+
+    public function test_max_file_bytes_is_4_5_mb(): void
+    {
+        $this->assertSame(4_718_592, AnthropicClient::maxFileBytes());
+    }
+
+    // ── upload / delete (no-ops) ─────────────────────────────────────────────
+
+    public function test_upload_file_returns_null(): void
+    {
+        $this->assertNull($this->makeClient()->uploadFile('bytes', 'application/pdf'));
+    }
+
+    public function test_delete_file_is_noop(): void
+    {
+        $this->makeClient()->deleteFile('files/abc');
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_converse_with_file_ref_throws_logic_exception(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->makeClient()->converseWithFileRef('files/abc', 'application/pdf', 'test');
+    }
+
+    // ── converse ─────────────────────────────────────────────────────────────
+
+    public function test_converse_sends_correct_headers(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+
+        Http::assertSent(function (Request $req) {
+            return $req->header('x-api-key')[0] === 'test-key'
+                && $req->header('anthropic-version')[0] === '2023-06-01';
+        });
+    }
+
+    public function test_converse_sends_to_messages_endpoint(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+
+        Http::assertSent(fn (Request $req) => str_ends_with($req->url(), '/v1/messages'));
+    }
+
+    public function test_converse_sends_model_and_max_tokens(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+
+        Http::assertSent(function (Request $req) {
+            $body = $req->data();
+
+            return $body['model'] === 'claude-sonnet-4-6'
+                && isset($body['max_tokens']);
+        });
+    }
+
+    public function test_converse_converts_system_blocks_to_anthropic_format(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse(
+            system: [['text' => 'You are helpful.']],
+            messages: [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]],
+        );
+
+        Http::assertSent(function (Request $req) {
+            $system = $req->data()['system'] ?? [];
+
+            return ($system[0]['type'] ?? '') === 'text'
+                && ($system[0]['text'] ?? '') === 'You are helpful.';
+        });
+    }
+
+    public function test_converse_omits_system_key_when_empty(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+
+        Http::assertSent(fn (Request $req) => ! array_key_exists('system', $req->data()));
+    }
+
+    public function test_converse_includes_tools_when_provided(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $toolConfig = [
+            'tools' => [['name' => 'my_tool', 'description' => 'test', 'input_schema' => ['type' => 'object']]],
+            'tool_choice' => ['type' => 'auto'],
+        ];
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]], $toolConfig);
+
+        Http::assertSent(function (Request $req) {
+            $body = $req->data();
+
+            return isset($body['tools']) && isset($body['tool_choice']);
+        });
+    }
+
+    public function test_converse_omits_tools_when_null(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]], null);
+
+        Http::assertSent(function (Request $req) {
+            $body = $req->data();
+
+            return ! array_key_exists('tools', $body) && ! array_key_exists('tool_choice', $body);
+        });
+    }
+
+    public function test_converse_throws_rate_limit_exception_on_429(): void
+    {
+        Http::fake(['*' => Http::response(['error' => ['type' => 'rate_limit_error']], 429)]);
+
+        $this->expectException(GenAiRateLimitException::class);
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+    }
+
+    public function test_converse_throws_fatal_exception_on_400(): void
+    {
+        Http::fake(['*' => Http::response(['error' => ['type' => 'invalid_request_error']], 400)]);
+
+        $this->expectException(GenAiFatalException::class);
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+    }
+
+    public function test_converse_throws_fatal_exception_on_403(): void
+    {
+        Http::fake(['*' => Http::response(['error' => ['type' => 'permission_error']], 403)]);
+
+        $this->expectException(GenAiFatalException::class);
+        $this->makeClient()->converse([], [['role' => 'user', 'content' => [['type' => 'text', 'text' => 'hi']]]]);
+    }
+
+    // ── converseWithInlineFile ────────────────────────────────────────────────
+
+    public function test_converse_with_inline_file_embeds_base64_document_block(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $base64 = base64_encode('fake pdf bytes');
+        $this->makeClient()->converseWithInlineFile($base64, 'application/pdf', 'Summarize.');
+
+        Http::assertSent(function (Request $req) use ($base64) {
+            $content = $req->data()['messages'][0]['content'] ?? [];
+            foreach ($content as $block) {
+                if (
+                    ($block['type'] ?? '') === 'document'
+                    && ($block['source']['type'] ?? '') === 'base64'
+                    && ($block['source']['data'] ?? '') === $base64
+                    && ($block['source']['media_type'] ?? '') === 'application/pdf'
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    public function test_converse_with_inline_file_appends_text_prompt(): void
+    {
+        Http::fake(['*' => Http::response($this->fakeTextResponse())]);
+
+        $this->makeClient()->converseWithInlineFile(base64_encode('data'), 'application/pdf', 'What is this?');
+
+        Http::assertSent(function (Request $req) {
+            $content = $req->data()['messages'][0]['content'] ?? [];
+            foreach ($content as $block) {
+                if (($block['type'] ?? '') === 'text' && ($block['text'] ?? '') === 'What is this?') {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    // ── extractText ───────────────────────────────────────────────────────────
+
+    public function test_extract_text_returns_concatenated_text_blocks(): void
+    {
+        $response = [
+            'content' => [
+                ['type' => 'text', 'text' => 'Hello '],
+                ['type' => 'text', 'text' => 'world'],
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'ignored', 'input' => []],
+            ],
+        ];
+
+        $this->assertSame('Hello world', $this->makeClient()->extractText($response));
+    }
+
+    public function test_extract_text_returns_empty_string_for_missing_content(): void
+    {
+        $this->assertSame('', $this->makeClient()->extractText([]));
+    }
+
+    // ── extractToolCalls ──────────────────────────────────────────────────────
+
+    public function test_extract_tool_calls_parses_single_tool(): void
+    {
+        $response = [
+            'content' => [
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'classify_document', 'input' => ['document_type' => 'invoice']],
+            ],
+        ];
+
+        $calls = $this->makeClient()->extractToolCalls($response);
+        $this->assertCount(1, $calls);
+        $this->assertSame('classify_document', $calls[0]['name']);
+        $this->assertSame('invoice', $calls[0]['input']['document_type']);
+    }
+
+    public function test_extract_tool_calls_parses_multiple_tools(): void
+    {
+        $response = [
+            'content' => [
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'classify_document', 'input' => ['document_type' => 'p_and_l']],
+                ['type' => 'tool_use', 'id' => 'tu_2', 'name' => 'extract_data', 'input' => ['total' => 50000]],
+            ],
+        ];
+
+        $calls = $this->makeClient()->extractToolCalls($response);
+        $this->assertCount(2, $calls);
+        $this->assertSame('classify_document', $calls[0]['name']);
+        $this->assertSame('extract_data', $calls[1]['name']);
+        $this->assertSame(50000, $calls[1]['input']['total']);
+    }
+
+    public function test_extract_tool_calls_ignores_non_tool_blocks(): void
+    {
+        $response = [
+            'content' => [
+                ['type' => 'text', 'text' => 'Some text'],
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'my_tool', 'input' => []],
+            ],
+        ];
+
+        $calls = $this->makeClient()->extractToolCalls($response);
+        $this->assertCount(1, $calls);
+    }
+
+    public function test_extract_tool_calls_returns_empty_array_when_no_tools(): void
+    {
+        $response = ['content' => [['type' => 'text', 'text' => 'no tools here']]];
+        $this->assertSame([], $this->makeClient()->extractToolCalls($response));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `AnthropicClient` implementing the `GenAiClient` contract via the Anthropic Messages API (`api.anthropic.com`), independent of AWS Bedrock
- Wires the new provider into `GenAiClientFactory`, `GenAiServiceProvider`, and `config/genai.php`
- Adds 23 tests in `AnthropicClientTest` covering headers, payload shape, error handling, inline file embedding, and response extraction

## New config keys (`genai.providers.anthropic`)

| Key | Env var | Default |
|-----|---------|---------|
| `api_key` | `ANTHROPIC_API_KEY` | — |
| `model` | `ANTHROPIC_MODEL` | `claude-sonnet-4-6` |
| `max_tokens` | `ANTHROPIC_MAX_TOKENS` | `8192` |
| `timeout` | `ANTHROPIC_TIMEOUT` | `240` |

Set `GENAI_PROVIDER=anthropic` or resolve `genai.anthropic` from the container to use it explicitly.

## Test plan

- [x] All 94 tests pass (`composer test`)
- [x] `AnthropicClient::provider()` returns `"anthropic"`
- [x] Correct `x-api-key` and `anthropic-version` headers sent
- [x] System prompt blocks converted to Anthropic array format
- [x] Inline document blocks use `type: document / source: {type: base64}`
- [x] `extractText` and `extractToolCalls` parse Anthropic response shapes
- [x] 429 → `GenAiRateLimitException`, 400/403/404 → `GenAiFatalException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)