### PR TITLE
feat!: provider-agnostic token usage on GenAiResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,40 @@ $response = GenAi::converse($system, $messages, $toolConfig);
 |---|---|
 | `->text` | Concatenated text output |
 | `->toolCalls` | `[['name' => '...', 'input' => [...]], ...]` |
+| `->usage` | Normalised `Usage` (tokens, cache tokens) — see below |
 | `->raw` | Provider-specific raw response array |
 | `->hasToolCalls()` | Whether the model called any tool |
 | `->firstToolCall()` | First tool call, or `null` |
 | `->toolCallByName('fn')` | Named tool call, or `null` |
+
+### Token usage and cost
+
+Every response exposes a `Usage` object with provider-agnostic token counts. The
+clients normalise the three different wire shapes (Anthropic `input_tokens` /
+Bedrock `inputTokens` / Gemini `promptTokenCount`) into one API:
+
+```php
+$response = GenAiRequest::with($client)->prompt('...')->generate();
+
+$response->usage->inputTokens;              // non-cached prompt tokens
+$response->usage->outputTokens;             // completion tokens
+$response->usage->totalTokens;
+$response->usage->cacheReadInputTokens;     // served from prompt cache
+$response->usage->cacheCreationInputTokens; // written to prompt cache
+$response->usage->raw;                      // provider-specific payload
+
+// Estimate cost in USD given per-million-token prices for the model you used.
+$cost = $response->usage->estimatedCostUsd(
+    inputPerMillion: 3.00,
+    outputPerMillion: 15.00,
+    cacheReadPerMillion: 0.30,
+    cacheCreationPerMillion: 3.75,
+);
+```
+
+The three input buckets are non-overlapping (the Gemini adapter subtracts
+`cachedContentTokenCount` from `promptTokenCount` to match Anthropic/Bedrock
+semantics), so summing them gives total input work billed.
 
 ## Providers
 

--- a/src/Clients/AnthropicClient.php
+++ b/src/Clients/AnthropicClient.php
@@ -10,6 +10,7 @@ use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
+use Bherila\GenAiLaravel\Usage;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -180,6 +181,37 @@ class AnthropicClient implements GenAiClient
         }
 
         return $calls;
+    }
+
+    /**
+     * Extract normalised token usage from an Anthropic Messages API response.
+     *
+     * Anthropic reports input_tokens as non-cached input (cache_read and
+     * cache_creation are separate buckets), so the three input fields are
+     * already non-overlapping.
+     *
+     * @param  array<string, mixed>  $response
+     */
+    public function extractUsage(array $response): Usage
+    {
+        $u = $response['usage'] ?? null;
+        if (! is_array($u)) {
+            return Usage::empty();
+        }
+
+        $input = (int) ($u['input_tokens'] ?? 0);
+        $output = (int) ($u['output_tokens'] ?? 0);
+        $cacheRead = (int) ($u['cache_read_input_tokens'] ?? 0);
+        $cacheCreate = (int) ($u['cache_creation_input_tokens'] ?? 0);
+
+        return new Usage(
+            inputTokens: $input,
+            outputTokens: $output,
+            totalTokens: $input + $cacheRead + $cacheCreate + $output,
+            cacheReadInputTokens: $cacheRead,
+            cacheCreationInputTokens: $cacheCreate,
+            raw: $u,
+        );
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────────

--- a/src/Clients/BedrockClient.php
+++ b/src/Clients/BedrockClient.php
@@ -10,6 +10,7 @@ use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
+use Bherila\GenAiLaravel\Usage;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -179,6 +180,40 @@ class BedrockClient implements GenAiClient
         }
 
         return $calls;
+    }
+
+    /**
+     * Extract normalised token usage from a Bedrock Converse response.
+     *
+     * Bedrock's usage fields mirror Anthropic's semantics: inputTokens is the
+     * non-cached prompt count and cacheReadInputTokens / cacheWriteInputTokens
+     * are separate buckets (present only on cache-supporting models).
+     *
+     * @param  array<string, mixed>  $response
+     */
+    public function extractUsage(array $response): Usage
+    {
+        $u = $response['usage'] ?? null;
+        if (! is_array($u)) {
+            return Usage::empty();
+        }
+
+        $input = (int) ($u['inputTokens'] ?? 0);
+        $output = (int) ($u['outputTokens'] ?? 0);
+        $cacheRead = (int) ($u['cacheReadInputTokens'] ?? 0);
+        $cacheCreate = (int) ($u['cacheWriteInputTokens'] ?? 0);
+        $total = isset($u['totalTokens'])
+            ? (int) $u['totalTokens']
+            : $input + $cacheRead + $cacheCreate + $output;
+
+        return new Usage(
+            inputTokens: $input,
+            outputTokens: $output,
+            totalTokens: $total,
+            cacheReadInputTokens: $cacheRead,
+            cacheCreationInputTokens: $cacheCreate,
+            raw: $u,
+        );
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────────

--- a/src/Clients/GeminiClient.php
+++ b/src/Clients/GeminiClient.php
@@ -10,6 +10,7 @@ use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
+use Bherila\GenAiLaravel\Usage;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -237,6 +238,43 @@ class GeminiClient implements GenAiClient
         }
 
         return $calls;
+    }
+
+    /**
+     * Extract normalised token usage from a Gemini generateContent response.
+     *
+     * Gemini's promptTokenCount is inclusive of cached tokens — we subtract
+     * cachedContentTokenCount so inputTokens represents only the non-cached
+     * prompt portion, matching the non-overlapping bucket contract used by
+     * the Anthropic and Bedrock mappers.
+     *
+     * @param  array<string, mixed>  $response
+     */
+    public function extractUsage(array $response): Usage
+    {
+        $u = $response['usageMetadata'] ?? null;
+        if (! is_array($u)) {
+            return Usage::empty();
+        }
+
+        $prompt = (int) ($u['promptTokenCount'] ?? 0);
+        $output = (int) ($u['candidatesTokenCount'] ?? 0);
+        $cached = (int) ($u['cachedContentTokenCount'] ?? 0);
+        $total = isset($u['totalTokenCount']) ? (int) $u['totalTokenCount'] : $prompt + $output;
+
+        $nonCachedInput = $prompt - $cached;
+        if ($nonCachedInput < 0) {
+            $nonCachedInput = 0;
+        }
+
+        return new Usage(
+            inputTokens: $nonCachedInput,
+            outputTokens: $output,
+            totalTokens: $total,
+            cacheReadInputTokens: $cached,
+            cacheCreationInputTokens: 0,
+            raw: $u,
+        );
     }
 
     // ── Internal helpers ─────────────────────────────────────────────────────

--- a/src/Contracts/GenAiClient.php
+++ b/src/Contracts/GenAiClient.php
@@ -4,6 +4,7 @@ namespace Bherila\GenAiLaravel\Contracts;
 
 use Bherila\GenAiLaravel\ContentBlock;
 use Bherila\GenAiLaravel\ToolConfig;
+use Bherila\GenAiLaravel\Usage;
 
 /**
  * Provider-agnostic contract for GenAI clients.
@@ -84,4 +85,16 @@ interface GenAiClient
      * @return list<array{name: string, input: array<string, mixed>}>
      */
     public function extractToolCalls(array $response): array;
+
+    /**
+     * Extract normalised token-usage data from a raw provider response.
+     *
+     * Returns Usage::empty() when the provider omits usage (e.g. streaming chunks,
+     * error responses). Token counts are mapped into non-overlapping buckets so
+     * inputTokens + cacheReadInputTokens + cacheCreationInputTokens reflects total
+     * input work billed.
+     *
+     * @param  array<string, mixed>  $response
+     */
+    public function extractUsage(array $response): Usage;
 }

--- a/src/GenAiRequest.php
+++ b/src/GenAiRequest.php
@@ -124,6 +124,7 @@ final class GenAiRequest
         return new GenAiResponse(
             text: $this->client->extractText($raw),
             toolCalls: $this->client->extractToolCalls($raw),
+            usage: $this->client->extractUsage($raw),
             raw: $raw,
         );
     }

--- a/src/GenAiResponse.php
+++ b/src/GenAiResponse.php
@@ -13,11 +13,13 @@ final class GenAiResponse
     /**
      * @param  string  $text  Concatenated text output from the model.
      * @param  list<array{name: string, input: array<string, mixed>}>  $toolCalls  Tool/function calls made by the model.
+     * @param  Usage  $usage  Normalised token-usage data.
      * @param  array<string, mixed>  $raw  Provider-specific raw response (for advanced use / debugging).
      */
     public function __construct(
         public readonly string $text,
         public readonly array $toolCalls,
+        public readonly Usage $usage,
         public readonly array $raw,
     ) {}
 

--- a/src/Usage.php
+++ b/src/Usage.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Bherila\GenAiLaravel;
+
+/**
+ * Provider-agnostic token-usage data from a GenAI response.
+ *
+ * Every provider reports tokens under a different key (Anthropic: input_tokens /
+ * output_tokens; Bedrock: inputTokens / outputTokens; Gemini: promptTokenCount /
+ * candidatesTokenCount). This value object normalises them so call sites can read
+ * usage without branching on provider.
+ *
+ * Cost is not returned by any provider API — callers compute it from tokens using
+ * estimatedCostUsd() with per-million-token prices for the specific model in use.
+ */
+final class Usage
+{
+    /**
+     * @param  int  $inputTokens  Prompt / input tokens billed.
+     * @param  int  $outputTokens  Completion / output tokens billed.
+     * @param  int  $totalTokens  Sum reported by the provider when available, otherwise input + output.
+     * @param  int  $cacheReadInputTokens  Input tokens served from prompt cache (0 when unsupported / unused).
+     * @param  int  $cacheCreationInputTokens  Input tokens written to prompt cache (0 when unsupported / unused).
+     * @param  array<string, mixed>  $raw  Provider-specific raw usage payload, for fields not normalised here.
+     */
+    public function __construct(
+        public readonly int $inputTokens,
+        public readonly int $outputTokens,
+        public readonly int $totalTokens,
+        public readonly int $cacheReadInputTokens = 0,
+        public readonly int $cacheCreationInputTokens = 0,
+        public readonly array $raw = [],
+    ) {}
+
+    /**
+     * Zero-usage instance for responses where the provider returned no usage data.
+     */
+    public static function empty(): self
+    {
+        return new self(0, 0, 0);
+    }
+
+    /**
+     * Estimate cost in USD given per-million-token prices for the model.
+     *
+     * $inputTokens, $cacheReadInputTokens, and $cacheCreationInputTokens are treated as
+     * non-overlapping buckets — the Gemini client subtracts cached tokens from the prompt
+     * count so this invariant holds across providers. Cache prices default to the base
+     * input price when omitted, which matches providers that do not discount cache reads.
+     */
+    public function estimatedCostUsd(
+        float $inputPerMillion,
+        float $outputPerMillion,
+        ?float $cacheReadPerMillion = null,
+        ?float $cacheCreationPerMillion = null,
+    ): float {
+        $cacheReadPrice = $cacheReadPerMillion ?? $inputPerMillion;
+        $cacheCreationPrice = $cacheCreationPerMillion ?? $inputPerMillion;
+
+        return (
+            $this->inputTokens * $inputPerMillion
+            + $this->outputTokens * $outputPerMillion
+            + $this->cacheReadInputTokens * $cacheReadPrice
+            + $this->cacheCreationInputTokens * $cacheCreationPrice
+        ) / 1_000_000;
+    }
+}

--- a/tests/Unit/GenAiRequestTest.php
+++ b/tests/Unit/GenAiRequestTest.php
@@ -9,6 +9,7 @@ use Bherila\GenAiLaravel\Schema;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
+use Bherila\GenAiLaravel\Usage;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase;
@@ -172,6 +173,7 @@ class GenAiRequestTest extends TestCase
                 ['name' => 'fn_a', 'input' => ['x' => 1]],
                 ['name' => 'fn_b', 'input' => ['y' => 2]],
             ],
+            usage: Usage::empty(),
             raw: [],
         );
 
@@ -187,6 +189,7 @@ class GenAiRequestTest extends TestCase
                 ['name' => 'fn_a', 'input' => []],
                 ['name' => 'fn_b', 'input' => ['y' => 42]],
             ],
+            usage: Usage::empty(),
             raw: [],
         );
 
@@ -198,7 +201,7 @@ class GenAiRequestTest extends TestCase
 
     public function test_response_has_no_tool_calls_when_empty(): void
     {
-        $response = new GenAiResponse(text: 'hi', toolCalls: [], raw: []);
+        $response = new GenAiResponse(text: 'hi', toolCalls: [], usage: Usage::empty(), raw: []);
         $this->assertFalse($response->hasToolCalls());
         $this->assertNull($response->firstToolCall());
     }

--- a/tests/Unit/UsageTest.php
+++ b/tests/Unit/UsageTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Tests\Unit;
+
+use Bherila\GenAiLaravel\Clients\AnthropicClient;
+use Bherila\GenAiLaravel\Clients\BedrockClient;
+use Bherila\GenAiLaravel\Clients\GeminiClient;
+use Bherila\GenAiLaravel\Usage;
+use Orchestra\Testbench\TestCase;
+
+class UsageTest extends TestCase
+{
+    public function test_anthropic_extracts_input_output_tokens(): void
+    {
+        $client = new AnthropicClient(apiKey: 'test', model: 'claude-sonnet-4-6');
+
+        $usage = $client->extractUsage([
+            'usage' => ['input_tokens' => 123, 'output_tokens' => 45],
+        ]);
+
+        $this->assertSame(123, $usage->inputTokens);
+        $this->assertSame(45, $usage->outputTokens);
+        $this->assertSame(168, $usage->totalTokens);
+        $this->assertSame(0, $usage->cacheReadInputTokens);
+        $this->assertSame(0, $usage->cacheCreationInputTokens);
+    }
+
+    public function test_anthropic_extracts_cache_tokens(): void
+    {
+        $client = new AnthropicClient(apiKey: 'test', model: 'claude-sonnet-4-6');
+
+        $usage = $client->extractUsage([
+            'usage' => [
+                'input_tokens' => 100,
+                'output_tokens' => 20,
+                'cache_read_input_tokens' => 500,
+                'cache_creation_input_tokens' => 50,
+            ],
+        ]);
+
+        $this->assertSame(100, $usage->inputTokens);
+        $this->assertSame(20, $usage->outputTokens);
+        $this->assertSame(500, $usage->cacheReadInputTokens);
+        $this->assertSame(50, $usage->cacheCreationInputTokens);
+        $this->assertSame(670, $usage->totalTokens);
+    }
+
+    public function test_anthropic_missing_usage_returns_empty(): void
+    {
+        $client = new AnthropicClient(apiKey: 'test', model: 'claude-sonnet-4-6');
+
+        $usage = $client->extractUsage(['content' => []]);
+
+        $this->assertSame(0, $usage->inputTokens);
+        $this->assertSame(0, $usage->outputTokens);
+        $this->assertSame(0, $usage->totalTokens);
+    }
+
+    public function test_bedrock_extracts_input_output_tokens(): void
+    {
+        $client = new BedrockClient(apiKey: 'test', modelId: 'some-model');
+
+        $usage = $client->extractUsage([
+            'usage' => ['inputTokens' => 200, 'outputTokens' => 80, 'totalTokens' => 280],
+        ]);
+
+        $this->assertSame(200, $usage->inputTokens);
+        $this->assertSame(80, $usage->outputTokens);
+        $this->assertSame(280, $usage->totalTokens);
+    }
+
+    public function test_bedrock_extracts_cache_tokens(): void
+    {
+        $client = new BedrockClient(apiKey: 'test', modelId: 'some-model');
+
+        $usage = $client->extractUsage([
+            'usage' => [
+                'inputTokens' => 50,
+                'outputTokens' => 10,
+                'cacheReadInputTokens' => 300,
+                'cacheWriteInputTokens' => 20,
+                'totalTokens' => 380,
+            ],
+        ]);
+
+        $this->assertSame(50, $usage->inputTokens);
+        $this->assertSame(10, $usage->outputTokens);
+        $this->assertSame(300, $usage->cacheReadInputTokens);
+        $this->assertSame(20, $usage->cacheCreationInputTokens);
+        $this->assertSame(380, $usage->totalTokens);
+    }
+
+    public function test_bedrock_missing_total_is_derived(): void
+    {
+        $client = new BedrockClient(apiKey: 'test', modelId: 'some-model');
+
+        $usage = $client->extractUsage([
+            'usage' => ['inputTokens' => 10, 'outputTokens' => 7],
+        ]);
+
+        $this->assertSame(17, $usage->totalTokens);
+    }
+
+    public function test_gemini_extracts_tokens_and_subtracts_cache(): void
+    {
+        $client = new GeminiClient(apiKey: 'test');
+
+        $usage = $client->extractUsage([
+            'usageMetadata' => [
+                'promptTokenCount' => 300,
+                'candidatesTokenCount' => 90,
+                'cachedContentTokenCount' => 200,
+                'totalTokenCount' => 390,
+            ],
+        ]);
+
+        // promptTokenCount is inclusive of cache; inputTokens should be non-cached only.
+        $this->assertSame(100, $usage->inputTokens);
+        $this->assertSame(90, $usage->outputTokens);
+        $this->assertSame(200, $usage->cacheReadInputTokens);
+        $this->assertSame(0, $usage->cacheCreationInputTokens);
+        $this->assertSame(390, $usage->totalTokens);
+    }
+
+    public function test_gemini_missing_metadata_returns_empty(): void
+    {
+        $client = new GeminiClient(apiKey: 'test');
+
+        $usage = $client->extractUsage(['candidates' => []]);
+
+        $this->assertSame(0, $usage->inputTokens);
+        $this->assertSame(0, $usage->totalTokens);
+    }
+
+    public function test_estimated_cost_usd_base_pricing(): void
+    {
+        $usage = new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+            totalTokens: 1_500_000,
+        );
+
+        // $3/M input + $15/M output = 3 + 7.5 = 10.5
+        $this->assertEqualsWithDelta(10.5, $usage->estimatedCostUsd(3.0, 15.0), 1e-9);
+    }
+
+    public function test_estimated_cost_usd_with_cache_pricing(): void
+    {
+        $usage = new Usage(
+            inputTokens: 1_000_000,
+            outputTokens: 0,
+            totalTokens: 2_050_000,
+            cacheReadInputTokens: 1_000_000,
+            cacheCreationInputTokens: 50_000,
+        );
+
+        // input: 1M * $3 = 3; cacheRead: 1M * $0.30 = 0.30; cacheCreation: 50k * $3.75 = 0.1875
+        $cost = $usage->estimatedCostUsd(
+            inputPerMillion: 3.0,
+            outputPerMillion: 15.0,
+            cacheReadPerMillion: 0.30,
+            cacheCreationPerMillion: 3.75,
+        );
+
+        $this->assertEqualsWithDelta(3.4875, $cost, 1e-9);
+    }
+
+    public function test_estimated_cost_defaults_cache_to_input_price(): void
+    {
+        $usage = new Usage(
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 1_000_000,
+            cacheReadInputTokens: 1_000_000,
+        );
+
+        // No override → cache reads billed at input price ($3/M).
+        $this->assertEqualsWithDelta(3.0, $usage->estimatedCostUsd(3.0, 15.0), 1e-9);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `Usage` value object exposed as `GenAiResponse->usage`, normalising token counts across all three providers so call sites don't have to know provider-specific response shapes (Anthropic `input_tokens`, Bedrock `inputTokens`, Gemini `promptTokenCount`).
- Surfaces cache usage where reported (Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens`, Bedrock `cacheReadInputTokens` / `cacheWriteInputTokens`, Gemini `cachedContentTokenCount`). Input buckets are kept non-overlapping across providers — the Gemini adapter subtracts cached tokens from `promptTokenCount` to match Anthropic/Bedrock semantics.
- Adds `Usage::estimatedCostUsd()` so callers can compute cost from tokens given per-million pricing for the model they used (pricing varies per model and changes over time, so the package intentionally does not hard-code a table).

## Breaking changes

- `GenAiResponse::__construct` gains a required `Usage $usage` parameter.
- `GenAiClient` interface gains `extractUsage(array): Usage`. Custom client implementations must implement it.
- Direct `new GenAiResponse(...)` callers must pass a `Usage` — use `Usage::empty()` when no usage is available.

## Test plan

- [x] `vendor/bin/phpunit` — 134 tests, 204 assertions passing locally
- [x] New `UsageTest` covers Anthropic / Bedrock / Gemini extraction, empty-usage fallbacks, totalTokens derivation, and cost estimation with and without cache pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)