### PR TITLE
feat: fetch inference profiles in listModels to surface cross-region models

### DIFF
--- a/src/Clients/BedrockClient.php
+++ b/src/Clients/BedrockClient.php
@@ -33,6 +33,8 @@ use Illuminate\Support\Facades\Log;
  */
 class BedrockClient implements GenAiClient
 {
+    private const MAX_LIST_RETRY_ATTEMPTS = 3;
+
     private string $modelId;
 
     private string $region;
@@ -210,10 +212,8 @@ class BedrockClient implements GenAiClient
         $models = [];
 
         // Foundation models — single page, no pagination.
-        $response = $this->http->get("{$baseUrl}/foundation-models");
-        if (! $response->successful()) {
-            $this->throwListModelsError($response, 'foundation-models');
-        }
+        $response = $this->getWithRetry("{$baseUrl}/foundation-models");
+
         foreach ($response->json()['modelSummaries'] ?? [] as $entry) {
             $id = (string) ($entry['modelId'] ?? '');
             if ($id === '') {
@@ -234,10 +234,8 @@ class BedrockClient implements GenAiClient
         $nextToken = null;
         do {
             $params = $nextToken !== null ? ['nextToken' => $nextToken] : [];
-            $response = $this->http->get("{$baseUrl}/inference-profiles", $params);
-            if (! $response->successful()) {
-                $this->throwListModelsError($response, 'inference-profiles');
-            }
+            $response = $this->getWithRetry("{$baseUrl}/inference-profiles", $params);
+
             $payload = $response->json() ?? [];
             foreach ($payload['inferenceProfileSummaries'] ?? [] as $entry) {
                 $id = (string) ($entry['inferenceProfileId'] ?? '');
@@ -258,6 +256,28 @@ class BedrockClient implements GenAiClient
         return $models;
     }
 
+    /**
+     * GET with retry-on-429 for listModels control-plane calls.
+     * Honors the Retry-After header; falls back to exponential backoff (1s, 2s, 4s…).
+     *
+     * @param  array<string, mixed>  $params
+     */
+    private function getWithRetry(string $url, array $params = []): \Illuminate\Http\Client\Response
+    {
+        for ($attempt = 0; ; $attempt++) {
+            $response = $this->http->get($url, $params);
+            if ($response->successful()) {
+                return $response;
+            }
+            if ($response->status() === 429 && $attempt < self::MAX_LIST_RETRY_ATTEMPTS - 1) {
+                $header = $response->header('Retry-After');
+                sleep($header !== '' ? (int) $header : (1 << $attempt));
+                continue;
+            }
+            $this->throwListModelsError($response, ltrim((string) parse_url($url, PHP_URL_PATH), '/'));
+        }
+    }
+
     private function throwListModelsError(\Illuminate\Http\Client\Response $response, string $endpoint): never
     {
         Log::error("Bedrock list {$endpoint} failed", [
@@ -266,7 +286,8 @@ class BedrockClient implements GenAiClient
         ]);
 
         if ($response->status() === 429) {
-            throw new GenAiRateLimitException('Bedrock rate limit exceeded.');
+            $header = $response->header('Retry-After');
+            throw new GenAiRateLimitException('Bedrock rate limit exceeded.', $header !== '' ? (int) $header : null);
         }
         if (in_array($response->status(), [400, 401, 403, 404], true)) {
             throw new GenAiFatalException('Bedrock list models error: '.$response->body());

--- a/src/Clients/BedrockClient.php
+++ b/src/Clients/BedrockClient.php
@@ -192,58 +192,86 @@ class BedrockClient implements GenAiClient
     }
 
     /**
-     * List foundation models available in this Bedrock region.
+     * List models available in this Bedrock region.
      *
-     * Hits the Bedrock *control-plane* endpoint (`bedrock.REGION.amazonaws.com`)
-     * rather than the runtime endpoint used for inference. Returns the union of
-     * all providers available through Bedrock — filter by ModelInfo::$raw['providerName']
-     * if you only want Anthropic / Meta / etc.
+     * Calls two control-plane endpoints and merges the results:
+     * - `/foundation-models`  — base models (no pagination)
+     * - `/inference-profiles` — cross-region inference profiles, e.g.
+     *   `us.anthropic.claude-haiku-4-20250514-v1:0` (paginated via nextToken)
+     *
+     * Filter by ModelInfo::$raw['providerName'] or ModelInfo::$raw['type'] to
+     * narrow to a specific provider or profile type (SYSTEM_DEFINED / APPLICATION).
      *
      * @return list<ModelInfo>
      */
     public function listModels(): array
     {
-        $url = "https://bedrock.{$this->region}.amazonaws.com/foundation-models";
-        $response = $this->http->get($url);
-
-        if (! $response->successful()) {
-            Log::error('Bedrock list foundation models failed', [
-                'status' => $response->status(),
-                'body' => $response->body(),
-            ]);
-
-            if ($response->status() === 429) {
-                throw new GenAiRateLimitException('Bedrock rate limit exceeded.');
-            }
-            if (in_array($response->status(), [400, 401, 403, 404], true)) {
-                throw new GenAiFatalException('Bedrock list models error: '.$response->body());
-            }
-            throw new GenAiException('Bedrock API error '.$response->status().': '.$response->body());
-        }
-
-        $payload = $response->json() ?? [];
+        $baseUrl = "https://bedrock.{$this->region}.amazonaws.com";
         $models = [];
-        foreach ($payload['modelSummaries'] ?? [] as $entry) {
+
+        // Foundation models — single page, no pagination.
+        $response = $this->http->get("{$baseUrl}/foundation-models");
+        if (! $response->successful()) {
+            $this->throwListModelsError($response, 'foundation-models');
+        }
+        foreach ($response->json()['modelSummaries'] ?? [] as $entry) {
             $id = (string) ($entry['modelId'] ?? '');
             if ($id === '') {
                 continue;
             }
             $name = (string) ($entry['modelName'] ?? $id);
             $provider = $entry['providerName'] ?? null;
-            $description = is_string($provider) && $provider !== ''
-                ? "Provider: {$provider}"
-                : null;
-
             $models[] = new ModelInfo(
                 id: $id,
                 name: $name,
                 provider: 'bedrock',
-                description: $description,
+                description: is_string($provider) && $provider !== '' ? "Provider: {$provider}" : null,
                 raw: is_array($entry) ? $entry : [],
             );
         }
 
+        // Inference profiles — paginated; includes cross-region profiles missing from /foundation-models.
+        $nextToken = null;
+        do {
+            $params = $nextToken !== null ? ['nextToken' => $nextToken] : [];
+            $response = $this->http->get("{$baseUrl}/inference-profiles", $params);
+            if (! $response->successful()) {
+                $this->throwListModelsError($response, 'inference-profiles');
+            }
+            $payload = $response->json() ?? [];
+            foreach ($payload['inferenceProfileSummaries'] ?? [] as $entry) {
+                $id = (string) ($entry['inferenceProfileId'] ?? '');
+                if ($id === '') {
+                    continue;
+                }
+                $models[] = new ModelInfo(
+                    id: $id,
+                    name: (string) ($entry['inferenceProfileName'] ?? $id),
+                    provider: 'bedrock',
+                    description: isset($entry['description']) && $entry['description'] !== '' ? (string) $entry['description'] : null,
+                    raw: is_array($entry) ? $entry : [],
+                );
+            }
+            $nextToken = isset($payload['nextToken']) && is_string($payload['nextToken']) ? $payload['nextToken'] : null;
+        } while ($nextToken !== null);
+
         return $models;
+    }
+
+    private function throwListModelsError(\Illuminate\Http\Client\Response $response, string $endpoint): never
+    {
+        Log::error("Bedrock list {$endpoint} failed", [
+            'status' => $response->status(),
+            'body' => $response->body(),
+        ]);
+
+        if ($response->status() === 429) {
+            throw new GenAiRateLimitException('Bedrock rate limit exceeded.');
+        }
+        if (in_array($response->status(), [400, 401, 403, 404], true)) {
+            throw new GenAiFatalException('Bedrock list models error: '.$response->body());
+        }
+        throw new GenAiException('Bedrock API error '.$response->status().': '.$response->body());
     }
 
     /**

--- a/src/Exceptions/GenAiRateLimitException.php
+++ b/src/Exceptions/GenAiRateLimitException.php
@@ -4,6 +4,12 @@ namespace Bherila\GenAiLaravel\Exceptions;
 
 /**
  * Thrown when a provider returns a rate-limit (429) response.
- * Callers may retry after a delay.
+ * retryAfter carries the server-suggested delay in seconds (from Retry-After header), or null if absent.
  */
-class GenAiRateLimitException extends GenAiException {}
+class GenAiRateLimitException extends GenAiException
+{
+    public function __construct(string $message, public readonly ?int $retryAfter = null)
+    {
+        parent::__construct($message);
+    }
+}

--- a/tests/Unit/ListModelsTest.php
+++ b/tests/Unit/ListModelsTest.php
@@ -208,6 +208,59 @@ class ListModelsTest extends TestCase
         (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
     }
 
+    public function test_bedrock_list_models_retries_on_429_and_succeeds(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount === 1
+                    ? Http::response([], 429, ['Retry-After' => '0'])
+                    : Http::response(['modelSummaries' => [['modelId' => 'found-after-retry', 'modelName' => 'M']]]);
+            },
+            'https://bedrock.us-east-1.amazonaws.com/inference-profiles' => Http::response(['inferenceProfileSummaries' => []]),
+        ]);
+
+        $models = (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('found-after-retry', $models[0]->id);
+        $this->assertSame(2, $callCount);
+    }
+
+    public function test_bedrock_list_models_throws_after_max_retry_attempts(): void
+    {
+        Http::fake([
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models' => Http::response([], 429, ['Retry-After' => '0']),
+        ]);
+
+        $this->expectException(\Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException::class);
+        (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
+    }
+
+    public function test_bedrock_list_models_exposes_retry_after_on_exception(): void
+    {
+        // First two calls (retried) use Retry-After: 0 to avoid sleeping; third exhausts budget with Retry-After: 42.
+        $callCount = 0;
+        Http::fake([
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models' => function () use (&$callCount) {
+                $callCount++;
+                $header = $callCount < 3 ? '0' : '42';
+
+                return Http::response([], 429, ['Retry-After' => $header]);
+            },
+        ]);
+
+        try {
+            (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
+            $this->fail('Expected GenAiRateLimitException');
+        } catch (\Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException $e) {
+            $this->assertSame(42, $e->retryAfter);
+            $this->assertSame(3, $callCount);
+        }
+    }
+
     // ── Gemini ───────────────────────────────────────────────────────────────
 
     public function test_gemini_list_models_normalises_entries(): void

--- a/tests/Unit/ListModelsTest.php
+++ b/tests/Unit/ListModelsTest.php
@@ -110,6 +110,9 @@ class ListModelsTest extends TestCase
                     ],
                 ],
             ]),
+            'https://bedrock.us-east-1.amazonaws.com/inference-profiles' => Http::response([
+                'inferenceProfileSummaries' => [],
+            ]),
         ]);
 
         $client = new BedrockClient(apiKey: 'test', modelId: 'anthropic.claude-3-sonnet-20240229-v1:0');
@@ -123,11 +126,74 @@ class ListModelsTest extends TestCase
         $this->assertSame('Meta', $models[1]->raw['providerName']);
 
         Http::assertSent(fn (Request $req) => $req->url() === 'https://bedrock.us-east-1.amazonaws.com/foundation-models');
+        Http::assertSent(fn (Request $req) => $req->url() === 'https://bedrock.us-east-1.amazonaws.com/inference-profiles');
+    }
+
+    public function test_bedrock_list_models_includes_inference_profiles(): void
+    {
+        Http::fake([
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models' => Http::response(['modelSummaries' => []]),
+            'https://bedrock.us-east-1.amazonaws.com/inference-profiles' => Http::response([
+                'inferenceProfileSummaries' => [
+                    [
+                        'inferenceProfileId' => 'us.anthropic.claude-haiku-4-20250514-v1:0',
+                        'inferenceProfileName' => 'Cross-region Anthropic Claude Haiku 4',
+                        'inferenceProfileArn' => 'arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-haiku-4-20250514-v1:0',
+                        'type' => 'SYSTEM_DEFINED',
+                        'status' => 'ACTIVE',
+                        'description' => 'Routes across US regions',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $models = (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
+
+        $this->assertCount(1, $models);
+        $this->assertSame('us.anthropic.claude-haiku-4-20250514-v1:0', $models[0]->id);
+        $this->assertSame('Cross-region Anthropic Claude Haiku 4', $models[0]->name);
+        $this->assertSame('bedrock', $models[0]->provider);
+        $this->assertSame('Routes across US regions', $models[0]->description);
+        $this->assertSame('SYSTEM_DEFINED', $models[0]->raw['type']);
+    }
+
+    public function test_bedrock_list_models_paginates_inference_profiles(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models' => Http::response(['modelSummaries' => []]),
+            'https://bedrock.us-east-1.amazonaws.com/inference-profiles*' => function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return Http::response([
+                        'inferenceProfileSummaries' => [[
+                            'inferenceProfileId' => 'us.anthropic.claude-sonnet-4-6',
+                            'inferenceProfileName' => 'Profile A',
+                        ]],
+                        'nextToken' => 'page-2-token',
+                    ]);
+                }
+
+                return Http::response([
+                    'inferenceProfileSummaries' => [[
+                        'inferenceProfileId' => 'eu.anthropic.claude-sonnet-4-6',
+                        'inferenceProfileName' => 'Profile B',
+                    ]],
+                ]);
+            },
+        ]);
+
+        $models = (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
+
+        $this->assertCount(2, $models);
+        $this->assertSame('us.anthropic.claude-sonnet-4-6', $models[0]->id);
+        $this->assertSame('eu.anthropic.claude-sonnet-4-6', $models[1]->id);
+        Http::assertSent(fn (Request $req) => str_contains($req->url(), 'nextToken=page-2-token'));
     }
 
     public function test_bedrock_list_models_uses_configured_region(): void
     {
-        Http::fake(['*' => Http::response(['modelSummaries' => []])]);
+        Http::fake(['*' => Http::response(['modelSummaries' => [], 'inferenceProfileSummaries' => []])]);
 
         (new BedrockClient(apiKey: 'test', modelId: 'anything', region: 'eu-west-1'))->listModels();
 


### PR DESCRIPTION
## Summary

- `GET /foundation-models` does not return cross-region inference profiles (e.g. `us.anthropic.claude-haiku-4-20250514-v1:0`) — those live at the separate `GET /inference-profiles` endpoint
- `listModels()` now calls both endpoints and merges results
- `/inference-profiles` is paginated via `nextToken`; the implementation follows all pages

## Test plan

- [ ] Existing Bedrock tests updated to fake both endpoints — all pass
- [ ] `test_bedrock_list_models_includes_inference_profiles` — verifies profiles appear in results
- [ ] `test_bedrock_list_models_paginates_inference_profiles` — verifies `nextToken` loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)