### PR TITLE
feat: shared HTTP retry layer + Bedrock auth doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ GENAI_PROVIDER=gemini
 GEMINI_API_KEY=your-key
 GEMINI_MODEL=gemini-2.0-flash
 
-# Bedrock
-BEDROCK_API_KEY=your-aws-access-key-id
+# Bedrock — uses Bearer-token auth, not AWS SigV4
+BEDROCK_API_KEY=your-bedrock-bearer-token
 BEDROCK_SESSION_TOKEN=   # optional, for temporary credentials
 BEDROCK_REGION=us-east-1
 BEDROCK_MODEL=us.anthropic.claude-haiku-4-20250514-v1:0
@@ -37,6 +37,13 @@ ANTHROPIC_API_KEY=your-key
 ANTHROPIC_MODEL=claude-sonnet-4-6
 ANTHROPIC_MAX_TOKENS=8192
 ```
+
+> **Bedrock auth:** this package authenticates against Bedrock with a bearer
+> token (`Authorization: Bearer …`), not AWS SigV4. `BEDROCK_API_KEY` is the
+> bearer token itself — there is no separate `BEDROCK_SECRET_KEY`. If you are
+> coming from the AWS SDK and have IAM access-key-ID + secret-access-key
+> credentials, those are not the right shape for this package; use a Bedrock
+> bearer token instead.
 
 ## Usage
 
@@ -232,6 +239,32 @@ $cost = $response->usage->estimatedCostUsd(
 The three input buckets are non-overlapping (the Gemini adapter subtracts
 `cachedContentTokenCount` from `promptTokenCount` to match Anthropic/Bedrock
 semantics), so summing them gives total input work billed.
+
+## Retry behaviour
+
+All providers retry transient failures transparently. `429` honors the
+`Retry-After: <seconds>` response header; `502 / 503 / 504` use exponential
+backoff. `400 / 401 / 403 / 404` are never retried. After the budget is spent,
+`GenAiRateLimitException::$retryAfter` carries the last server-suggested delay
+so you can re-queue work.
+
+```env
+GENAI_RETRY_MAX_ATTEMPTS=3        # total attempts including the first; 1 disables retries
+GENAI_RETRY_BACKOFF_BASE_MS=1000  # exponential backoff base (no Retry-After header)
+GENAI_RETRY_BACKOFF_MAX_MS=30000  # cap on any single sleep
+```
+
+Override per client by passing a `RetryStrategy` to the constructor — useful in
+tests, where injecting a `sleeper` closure keeps the suite fast:
+
+```php
+use Bherila\GenAiLaravel\Http\RetryStrategy;
+
+new AnthropicClient(
+    apiKey: '...',
+    retry: new RetryStrategy(maxAttempts: 1), // disable retries
+);
+```
 
 ## Listing models
 

--- a/config/genai.php
+++ b/config/genai.php
@@ -11,6 +11,19 @@ return [
     */
     'default' => env('GENAI_PROVIDER', 'gemini'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Retry policy (applies to all providers)
+    |--------------------------------------------------------------------------
+    | Retries 429 (honoring `Retry-After`) and transient 5xx (502/503/504).
+    | `max_attempts` includes the first request; set to 1 to disable retries.
+    */
+    'retry' => [
+        'max_attempts' => (int) env('GENAI_RETRY_MAX_ATTEMPTS', 3),
+        'backoff_base_ms' => (int) env('GENAI_RETRY_BACKOFF_BASE_MS', 1000),
+        'backoff_max_ms' => (int) env('GENAI_RETRY_BACKOFF_MAX_MS', 30000),
+    ],
+
     'providers' => [
 
         /*
@@ -55,13 +68,12 @@ return [
         |--------------------------------------------------------------------------
         */
         'bedrock' => [
-            // AWS access key ID.
+            // Bearer token sent as `Authorization: Bearer {api_key}`. This package
+            // does not use AWS SigV4 — `api_key` is the bearer token itself, not
+            // an AWS access key ID.
             'api_key' => env('BEDROCK_API_KEY'),
 
-            // AWS secret access key (used as Bearer token in Bedrock's HTTP auth).
-            'secret_key' => env('BEDROCK_SECRET_KEY'),
-
-            // STS session token — required when using temporary IAM credentials.
+            // Optional STS session token, sent as X-Amz-Security-Token.
             'session_token' => env('BEDROCK_SESSION_TOKEN'),
 
             // AWS region.

--- a/src/Clients/AnthropicClient.php
+++ b/src/Clients/AnthropicClient.php
@@ -4,18 +4,17 @@ namespace Bherila\GenAiLaravel\Clients;
 
 use Bherila\GenAiLaravel\ContentBlock;
 use Bherila\GenAiLaravel\Contracts\GenAiClient;
-use Bherila\GenAiLaravel\Exceptions\GenAiException;
 use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
-use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\FileConversion\SpreadsheetToText;
 use Bherila\GenAiLaravel\FileConversion\WordDocumentToPdf;
+use Bherila\GenAiLaravel\Http\RetryStrategy;
 use Bherila\GenAiLaravel\ModelInfo;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
 use Bherila\GenAiLaravel\Usage;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 
 /**
  * Anthropic Messages API implementation of GenAiClient.
@@ -69,13 +68,16 @@ class AnthropicClient implements GenAiClient
 
     private int $maxTokens;
 
-    private \Illuminate\Http\Client\PendingRequest $http;
+    private PendingRequest $http;
+
+    private RetryStrategy $retry;
 
     public function __construct(
         string $apiKey,
         string $model = 'claude-sonnet-4-6',
         int $maxTokens = 8192,
         int $timeout = 240,
+        ?RetryStrategy $retry = null,
     ) {
         $this->model = $model;
         $this->maxTokens = $maxTokens;
@@ -84,6 +86,7 @@ class AnthropicClient implements GenAiClient
             'anthropic-version' => self::API_VERSION,
             'Content-Type' => 'application/json',
         ])->timeout($timeout);
+        $this->retry = $retry ?? RetryStrategy::fromConfig();
     }
 
     public function provider(): string
@@ -190,24 +193,10 @@ class AnthropicClient implements GenAiClient
             $payload['tool_choice'] = $native['tool_choice'];
         }
 
-        $response = $this->http->post(self::API_BASE.'/v1/messages', $payload);
-
-        if (! $response->successful()) {
-            Log::error('Anthropic API request failed', [
-                'status' => $response->status(),
-                'body' => $response->body(),
-            ]);
-
-            if ($response->status() === 429) {
-                throw new GenAiRateLimitException('Anthropic API rate limit exceeded.');
-            }
-
-            if (in_array($response->status(), [400, 403, 404], true)) {
-                throw new GenAiFatalException('Anthropic API error: '.$response->body());
-            }
-
-            throw new GenAiException('Anthropic API error '.$response->status().': '.$response->body());
-        }
+        $response = $this->retry->execute(
+            fn () => $this->http->post(self::API_BASE.'/v1/messages', $payload),
+            'Anthropic Messages',
+        );
 
         return $response->json() ?? [];
     }
@@ -270,24 +259,10 @@ class AnthropicClient implements GenAiClient
                 $query['after_id'] = $afterId;
             }
 
-            $response = $this->http->get(self::API_BASE.'/v1/models', $query);
-
-            if (! $response->successful()) {
-                Log::error('Anthropic list models failed', [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
-
-                if ($response->status() === 429) {
-                    throw new GenAiRateLimitException('Anthropic API rate limit exceeded.');
-                }
-                if (in_array($response->status(), [400, 401, 403, 404], true)) {
-                    throw new GenAiFatalException('Anthropic API error: '.$response->body());
-                }
-                throw new GenAiException('Anthropic API error '.$response->status().': '.$response->body());
-            }
-
-            $payload = $response->json() ?? [];
+            $payload = $this->retry->execute(
+                fn () => $this->http->get(self::API_BASE.'/v1/models', $query),
+                'Anthropic list models',
+            )->json() ?? [];
             foreach ($payload['data'] ?? [] as $entry) {
                 $id = (string) ($entry['id'] ?? '');
                 if ($id === '') {

--- a/src/Clients/BedrockClient.php
+++ b/src/Clients/BedrockClient.php
@@ -4,16 +4,15 @@ namespace Bherila\GenAiLaravel\Clients;
 
 use Bherila\GenAiLaravel\ContentBlock;
 use Bherila\GenAiLaravel\Contracts\GenAiClient;
-use Bherila\GenAiLaravel\Exceptions\GenAiException;
 use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
-use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
+use Bherila\GenAiLaravel\Http\RetryStrategy;
 use Bherila\GenAiLaravel\ModelInfo;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
 use Bherila\GenAiLaravel\ToolDefinition;
 use Bherila\GenAiLaravel\Usage;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 
 /**
  * AWS Bedrock Converse API implementation of GenAiClient.
@@ -24,16 +23,20 @@ use Illuminate\Support\Facades\Log;
  * ToolConfig is translated to Bedrock toolSpec + toolChoice format.
  * ContentBlock objects are converted to Bedrock content block format.
  *
+ * Auth: this package uses Bearer-token auth (`Authorization: Bearer {api_key}`),
+ * not AWS Signature V4. `api_key` is the bearer token itself — not an AWS access
+ * key ID. Temporary credentials may add an STS session token.
+ *
  * Config keys (all under genai.providers.bedrock):
- *   api_key        — AWS access key ID
- *   secret_key     — AWS secret access key (passed as Bearer token)
- *   session_token  — optional STS session token
- *   region         — e.g. "us-east-1" (default: "us-east-1")
+ *   api_key        — Bearer token used for the Authorization header
+ *   session_token  — optional; sent as X-Amz-Security-Token header
+ *   region         — AWS region, e.g. "us-east-1" (default: "us-east-1")
  *   model          — model ID, e.g. "us.anthropic.claude-haiku-4-20250514-v1:0"
  */
 class BedrockClient implements GenAiClient
 {
-    private const MAX_LIST_RETRY_ATTEMPTS = 3;
+    /** Hard ceiling on `/inference-profiles` pages — defense in depth. */
+    private const MAX_INFERENCE_PROFILE_PAGES = 50;
 
     private string $modelId;
 
@@ -41,13 +44,16 @@ class BedrockClient implements GenAiClient
 
     private string $endpoint;
 
-    private \Illuminate\Http\Client\PendingRequest $http;
+    private PendingRequest $http;
+
+    private RetryStrategy $retry;
 
     public function __construct(
         string $apiKey,
         string $modelId,
         string $region = 'us-east-1',
         string $sessionToken = '',
+        ?RetryStrategy $retry = null,
     ) {
         $this->modelId = $modelId;
         $this->region = $region;
@@ -59,6 +65,7 @@ class BedrockClient implements GenAiClient
         }
 
         $this->http = Http::withToken($apiKey)->withHeaders($headers);
+        $this->retry = $retry ?? RetryStrategy::fromConfig();
     }
 
     public function provider(): string
@@ -128,25 +135,10 @@ class BedrockClient implements GenAiClient
             $payload['toolConfig'] = $this->toolConfigToBedrock($toolConfig);
         }
 
-        $response = $this->http
-            ->post("{$this->endpoint}/model/{$this->modelId}/converse", $payload);
-
-        if (! $response->successful()) {
-            Log::error('Bedrock Converse failed', [
-                'status' => $response->status(),
-                'body' => $response->body(),
-            ]);
-
-            if ($response->status() === 429) {
-                throw new GenAiRateLimitException('Bedrock rate limit exceeded.');
-            }
-
-            if ($response->status() === 400) {
-                throw new GenAiFatalException('Bedrock bad request: '.$response->body());
-            }
-
-            throw new GenAiException('Bedrock API error '.$response->status().': '.$response->body());
-        }
+        $response = $this->retry->execute(
+            fn () => $this->http->post("{$this->endpoint}/model/{$this->modelId}/converse", $payload),
+            'Bedrock Converse',
+        );
 
         return $response->json() ?? [];
     }
@@ -212,18 +204,20 @@ class BedrockClient implements GenAiClient
         $models = [];
 
         // Foundation models — single page, no pagination.
-        $response = $this->getWithRetry("{$baseUrl}/foundation-models");
+        $payload = $this->retry->execute(
+            fn () => $this->http->get("{$baseUrl}/foundation-models"),
+            'Bedrock list foundation-models',
+        )->json() ?? [];
 
-        foreach ($response->json()['modelSummaries'] ?? [] as $entry) {
+        foreach ($payload['modelSummaries'] ?? [] as $entry) {
             $id = (string) ($entry['modelId'] ?? '');
             if ($id === '') {
                 continue;
             }
-            $name = (string) ($entry['modelName'] ?? $id);
             $provider = $entry['providerName'] ?? null;
             $models[] = new ModelInfo(
                 id: $id,
-                name: $name,
+                name: (string) ($entry['modelName'] ?? $id),
                 provider: 'bedrock',
                 description: is_string($provider) && $provider !== '' ? "Provider: {$provider}" : null,
                 raw: is_array($entry) ? $entry : [],
@@ -232,11 +226,14 @@ class BedrockClient implements GenAiClient
 
         // Inference profiles — paginated; includes cross-region profiles missing from /foundation-models.
         $nextToken = null;
+        $page = 0;
         do {
             $params = $nextToken !== null ? ['nextToken' => $nextToken] : [];
-            $response = $this->getWithRetry("{$baseUrl}/inference-profiles", $params);
+            $payload = $this->retry->execute(
+                fn () => $this->http->get("{$baseUrl}/inference-profiles", $params),
+                'Bedrock list inference-profiles',
+            )->json() ?? [];
 
-            $payload = $response->json() ?? [];
             foreach ($payload['inferenceProfileSummaries'] ?? [] as $entry) {
                 $id = (string) ($entry['inferenceProfileId'] ?? '');
                 if ($id === '') {
@@ -251,48 +248,10 @@ class BedrockClient implements GenAiClient
                 );
             }
             $nextToken = isset($payload['nextToken']) && is_string($payload['nextToken']) ? $payload['nextToken'] : null;
-        } while ($nextToken !== null);
+            $page++;
+        } while ($nextToken !== null && $page < self::MAX_INFERENCE_PROFILE_PAGES);
 
         return $models;
-    }
-
-    /**
-     * GET with retry-on-429 for listModels control-plane calls.
-     * Honors the Retry-After header; falls back to exponential backoff (1s, 2s, 4s…).
-     *
-     * @param  array<string, mixed>  $params
-     */
-    private function getWithRetry(string $url, array $params = []): \Illuminate\Http\Client\Response
-    {
-        for ($attempt = 0; ; $attempt++) {
-            $response = $this->http->get($url, $params);
-            if ($response->successful()) {
-                return $response;
-            }
-            if ($response->status() === 429 && $attempt < self::MAX_LIST_RETRY_ATTEMPTS - 1) {
-                $header = $response->header('Retry-After');
-                sleep($header !== '' ? (int) $header : (1 << $attempt));
-                continue;
-            }
-            $this->throwListModelsError($response, ltrim((string) parse_url($url, PHP_URL_PATH), '/'));
-        }
-    }
-
-    private function throwListModelsError(\Illuminate\Http\Client\Response $response, string $endpoint): never
-    {
-        Log::error("Bedrock list {$endpoint} failed", [
-            'status' => $response->status(),
-            'body' => $response->body(),
-        ]);
-
-        if ($response->status() === 429) {
-            $header = $response->header('Retry-After');
-            throw new GenAiRateLimitException('Bedrock rate limit exceeded.', $header !== '' ? (int) $header : null);
-        }
-        if (in_array($response->status(), [400, 401, 403, 404], true)) {
-            throw new GenAiFatalException('Bedrock list models error: '.$response->body());
-        }
-        throw new GenAiException('Bedrock API error '.$response->status().': '.$response->body());
     }
 
     /**

--- a/src/Clients/GeminiClient.php
+++ b/src/Clients/GeminiClient.php
@@ -4,11 +4,10 @@ namespace Bherila\GenAiLaravel\Clients;
 
 use Bherila\GenAiLaravel\ContentBlock;
 use Bherila\GenAiLaravel\Contracts\GenAiClient;
-use Bherila\GenAiLaravel\Exceptions\GenAiException;
 use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
-use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\FileConversion\SpreadsheetToText;
 use Bherila\GenAiLaravel\FileConversion\WordDocumentToPdf;
+use Bherila\GenAiLaravel\Http\RetryStrategy;
 use Bherila\GenAiLaravel\ModelInfo;
 use Bherila\GenAiLaravel\ToolChoice;
 use Bherila\GenAiLaravel\ToolConfig;
@@ -44,11 +43,14 @@ class GeminiClient implements GenAiClient
 
     private int $timeout;
 
-    public function __construct(string $apiKey, string $model = 'gemini-2.0-flash', int $timeout = 240)
+    private RetryStrategy $retry;
+
+    public function __construct(string $apiKey, string $model = 'gemini-2.0-flash', int $timeout = 240, ?RetryStrategy $retry = null)
     {
         $this->apiKey = $apiKey;
         $this->model = $model;
         $this->timeout = $timeout;
+        $this->retry = $retry ?? RetryStrategy::fromConfig();
     }
 
     public function provider(): string
@@ -292,26 +294,12 @@ class GeminiClient implements GenAiClient
                 $query['pageToken'] = $pageToken;
             }
 
-            $response = Http::withHeaders(['x-goog-api-key' => $this->apiKey])
-                ->withOptions(['timeout' => $this->timeout])
-                ->get(self::BASE_URL.'/v1beta/models', $query);
-
-            if (! $response->successful()) {
-                Log::error('Gemini list models failed', [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
-
-                if ($response->status() === 429) {
-                    throw new GenAiRateLimitException('Gemini rate limit exceeded.');
-                }
-                if (in_array($response->status(), [400, 401, 403, 404], true)) {
-                    throw new GenAiFatalException('Gemini list models error: '.$response->body());
-                }
-                throw new GenAiException('Gemini API error '.$response->status().': '.$response->body());
-            }
-
-            $payload = $response->json() ?? [];
+            $payload = $this->retry->execute(
+                fn () => Http::withHeaders(['x-goog-api-key' => $this->apiKey])
+                    ->withOptions(['timeout' => $this->timeout])
+                    ->get(self::BASE_URL.'/v1beta/models', $query),
+                'Gemini list models',
+            )->json() ?? [];
             foreach ($payload['models'] ?? [] as $entry) {
                 $id = (string) ($entry['name'] ?? '');
                 if ($id === '') {
@@ -560,27 +548,13 @@ class GeminiClient implements GenAiClient
     {
         $url = self::BASE_URL."/v1beta/models/{$this->model}:generateContent";
 
-        $response = Http::withHeaders([
-            'x-goog-api-key' => $this->apiKey,
-            'Content-Type' => 'application/json',
-        ])->withOptions(['timeout' => $this->timeout])->post($url, $payload);
-
-        if (! $response->successful()) {
-            Log::error('Gemini generateContent failed', [
-                'status' => $response->status(),
-                'body' => $response->body(),
-            ]);
-
-            if ($response->status() === 429) {
-                throw new GenAiRateLimitException('Gemini rate limit exceeded.');
-            }
-
-            if ($response->status() === 400) {
-                throw new GenAiFatalException('Gemini bad request: '.$response->body());
-            }
-
-            throw new GenAiException('Gemini API error '.$response->status().': '.$response->body());
-        }
+        $response = $this->retry->execute(
+            fn () => Http::withHeaders([
+                'x-goog-api-key' => $this->apiKey,
+                'Content-Type' => 'application/json',
+            ])->withOptions(['timeout' => $this->timeout])->post($url, $payload),
+            'Gemini generateContent',
+        );
 
         return $response->json() ?? [];
     }

--- a/src/Http/RetryStrategy.php
+++ b/src/Http/RetryStrategy.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Http;
+
+use Bherila\GenAiLaravel\Exceptions\GenAiException;
+use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
+use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
+use Closure;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Single source of truth for HTTP retry behaviour across all GenAI clients.
+ *
+ * Retries 429 (honoring `Retry-After: <seconds>` when present) and transient
+ * 5xx (502/503/504); does not retry 400/401/403/404. After max_attempts the
+ * appropriate `GenAi*Exception` is thrown — `GenAiRateLimitException` carries
+ * the last server-suggested `retryAfter` so callers can still queue work.
+ *
+ * `max_attempts` counts the initial request: `max_attempts = 1` disables retry.
+ */
+class RetryStrategy
+{
+    /** Statuses that should be retried until the budget is exhausted. */
+    private const RETRYABLE_STATUSES = [429, 502, 503, 504];
+
+    /** Statuses that should never be retried — they will not change on retry. */
+    private const FATAL_STATUSES = [400, 401, 403, 404];
+
+    /**
+     * @param  Closure(int):void|null  $sleeper  Override `usleep()` for tests.
+     */
+    public function __construct(
+        public readonly int $maxAttempts = 3,
+        public readonly int $backoffBaseMs = 1000,
+        public readonly int $backoffMaxMs = 30_000,
+        private readonly ?Closure $sleeper = null,
+    ) {}
+
+    /**
+     * Build a strategy from `config('genai.retry')`, falling back to defaults.
+     */
+    public static function fromConfig(): self
+    {
+        $cfg = function_exists('config') ? (array) config('genai.retry', []) : [];
+
+        return new self(
+            maxAttempts: (int) ($cfg['max_attempts'] ?? 3),
+            backoffBaseMs: (int) ($cfg['backoff_base_ms'] ?? 1000),
+            backoffMaxMs: (int) ($cfg['backoff_max_ms'] ?? 30_000),
+        );
+    }
+
+    /**
+     * Run `$send` with retry. Throws on final failure.
+     *
+     * @param  callable():Response  $send
+     * @param  string  $errorContext  Used in log lines and exception messages
+     *                                (e.g. "Anthropic API", "Bedrock list models").
+     */
+    public function execute(callable $send, string $errorContext): Response
+    {
+        $attempt = 0;
+        while (true) {
+            $response = $send();
+            if ($response->successful()) {
+                return $response;
+            }
+
+            $status = $response->status();
+            $canRetry = $attempt < $this->maxAttempts - 1
+                && in_array($status, self::RETRYABLE_STATUSES, true);
+
+            if (! $canRetry) {
+                $this->throwFor($response, $errorContext);
+            }
+
+            $this->sleep($this->delayMsFor($response, $attempt));
+            $attempt++;
+        }
+    }
+
+    /**
+     * Delay before the next retry, in ms.
+     *
+     * Honors `Retry-After: <seconds>` on 429; otherwise exponential backoff
+     * (`backoffBaseMs * 2^attempt`). Always capped at `backoffMaxMs`.
+     */
+    private function delayMsFor(Response $response, int $attempt): int
+    {
+        if ($response->status() === 429) {
+            $header = $response->header('Retry-After');
+            if ($header !== '') {
+                return min(((int) $header) * 1000, $this->backoffMaxMs);
+            }
+        }
+
+        $base = $this->backoffBaseMs * (1 << $attempt);
+
+        return min($base, $this->backoffMaxMs);
+    }
+
+    private function sleep(int $ms): void
+    {
+        if ($ms <= 0) {
+            return;
+        }
+        if ($this->sleeper !== null) {
+            ($this->sleeper)($ms);
+
+            return;
+        }
+        usleep($ms * 1000);
+    }
+
+    private function throwFor(Response $response, string $errorContext): never
+    {
+        $status = $response->status();
+        $body = $response->body();
+
+        Log::error("{$errorContext} request failed", [
+            'status' => $status,
+            'body' => $body,
+        ]);
+
+        if ($status === 429) {
+            $header = $response->header('Retry-After');
+            $retryAfter = $header !== '' ? (int) $header : null;
+            throw new GenAiRateLimitException("{$errorContext} rate limit exceeded.", $retryAfter);
+        }
+        if (in_array($status, self::FATAL_STATUSES, true)) {
+            throw new GenAiFatalException("{$errorContext} error: {$body}");
+        }
+        throw new GenAiException("{$errorContext} error {$status}: {$body}");
+    }
+}

--- a/tests/Unit/ListModelsTest.php
+++ b/tests/Unit/ListModelsTest.php
@@ -6,6 +6,7 @@ use Bherila\GenAiLaravel\Clients\AnthropicClient;
 use Bherila\GenAiLaravel\Clients\BedrockClient;
 use Bherila\GenAiLaravel\Clients\GeminiClient;
 use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
+use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
 use Bherila\GenAiLaravel\ModelInfo;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -235,7 +236,7 @@ class ListModelsTest extends TestCase
             'https://bedrock.us-east-1.amazonaws.com/foundation-models' => Http::response([], 429, ['Retry-After' => '0']),
         ]);
 
-        $this->expectException(\Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException::class);
+        $this->expectException(GenAiRateLimitException::class);
         (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
     }
 
@@ -255,7 +256,7 @@ class ListModelsTest extends TestCase
         try {
             (new BedrockClient(apiKey: 'test', modelId: 'any'))->listModels();
             $this->fail('Expected GenAiRateLimitException');
-        } catch (\Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException $e) {
+        } catch (GenAiRateLimitException $e) {
             $this->assertSame(42, $e->retryAfter);
             $this->assertSame(3, $callCount);
         }

--- a/tests/Unit/RetryStrategyTest.php
+++ b/tests/Unit/RetryStrategyTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Tests\Unit;
+
+use Bherila\GenAiLaravel\Exceptions\GenAiException;
+use Bherila\GenAiLaravel\Exceptions\GenAiFatalException;
+use Bherila\GenAiLaravel\Exceptions\GenAiRateLimitException;
+use Bherila\GenAiLaravel\Http\RetryStrategy;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+
+class RetryStrategyTest extends TestCase
+{
+    /** @var list<int> */
+    private array $sleeps = [];
+
+    /**
+     * Build a strategy whose sleeper records ms into $this->sleeps so tests
+     * can assert delays without actually pausing the suite.
+     */
+    private function strategy(int $maxAttempts = 3, int $baseMs = 1000, int $maxMs = 30_000): RetryStrategy
+    {
+        $this->sleeps = [];
+
+        return new RetryStrategy(
+            maxAttempts: $maxAttempts,
+            backoffBaseMs: $baseMs,
+            backoffMaxMs: $maxMs,
+            sleeper: function (int $ms) {
+                $this->sleeps[] = $ms;
+            },
+        );
+    }
+
+    private function send(string $url): callable
+    {
+        return fn () => Http::get($url);
+    }
+
+    public function test_returns_immediately_on_success(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true])]);
+        $strategy = $this->strategy();
+
+        $response = $strategy->execute($this->send('https://x.test/ok'), 'X');
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->successful());
+        $this->assertSame([], $this->sleeps, 'No sleep should occur on a successful first request.');
+    }
+
+    public function test_429_with_retry_after_honors_header(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount === 1
+                    ? Http::response([], 429, ['Retry-After' => '7'])
+                    : Http::response(['ok' => true]);
+            },
+        ]);
+
+        $strategy = $this->strategy();
+
+        $response = $strategy->execute($this->send('https://x.test/r'), 'X');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame([7000], $this->sleeps);
+        $this->assertSame(2, $callCount);
+    }
+
+    public function test_429_without_retry_after_uses_exponential_backoff(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount < 3
+                    ? Http::response([], 429)
+                    : Http::response(['ok' => true]);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 3, baseMs: 100);
+
+        $strategy->execute($this->send('https://x.test/r'), 'X');
+
+        $this->assertSame([100, 200], $this->sleeps, 'First retry waits base*2^0; second waits base*2^1.');
+        $this->assertSame(3, $callCount);
+    }
+
+    public function test_503_is_retried_with_backoff(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount === 1
+                    ? Http::response([], 503)
+                    : Http::response(['ok' => true]);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 3, baseMs: 50);
+
+        $strategy->execute($this->send('https://x.test/r'), 'X');
+
+        $this->assertSame([50], $this->sleeps);
+        $this->assertSame(2, $callCount);
+    }
+
+    public function test_400_is_not_retried_and_throws_fatal(): void
+    {
+        Http::fake(['*' => Http::response(['error' => 'bad'], 400)]);
+        $strategy = $this->strategy();
+
+        $this->expectException(GenAiFatalException::class);
+        try {
+            $strategy->execute($this->send('https://x.test/r'), 'X');
+        } finally {
+            $this->assertSame([], $this->sleeps, '4xx must not trigger a retry.');
+        }
+    }
+
+    public function test_401_is_not_retried_and_throws_fatal(): void
+    {
+        Http::fake(['*' => Http::response([], 401)]);
+        $strategy = $this->strategy();
+
+        $this->expectException(GenAiFatalException::class);
+        $strategy->execute($this->send('https://x.test/r'), 'X');
+    }
+
+    public function test_500_falls_through_to_generic_genai_exception(): void
+    {
+        // 500 isn't in the retryable list (only 502/503/504 are) — must throw GenAiException.
+        Http::fake(['*' => Http::response([], 500)]);
+        $strategy = $this->strategy();
+
+        $this->expectException(GenAiException::class);
+        try {
+            $strategy->execute($this->send('https://x.test/r'), 'X');
+        } finally {
+            $this->assertSame([], $this->sleeps);
+        }
+    }
+
+    public function test_exhausted_429_throws_with_retry_after_populated(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+                $header = $callCount < 3 ? '0' : '99';
+
+                return Http::response([], 429, ['Retry-After' => $header]);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 3, baseMs: 1);
+
+        try {
+            $strategy->execute($this->send('https://x.test/r'), 'X');
+            $this->fail('Expected GenAiRateLimitException');
+        } catch (GenAiRateLimitException $e) {
+            $this->assertSame(99, $e->retryAfter, 'retryAfter reflects the last server-suggested delay.');
+            $this->assertSame(3, $callCount);
+        }
+    }
+
+    public function test_max_attempts_one_disables_retry(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return Http::response([], 429, ['Retry-After' => '0']);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 1);
+
+        $this->expectException(GenAiRateLimitException::class);
+        try {
+            $strategy->execute($this->send('https://x.test/r'), 'X');
+        } finally {
+            $this->assertSame(1, $callCount, 'No retry should happen when max_attempts=1.');
+            $this->assertSame([], $this->sleeps);
+        }
+    }
+
+    public function test_backoff_capped_at_max_ms(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount < 3
+                    ? Http::response([], 503)
+                    : Http::response(['ok' => true]);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 3, baseMs: 10_000, maxMs: 12_000);
+
+        $strategy->execute($this->send('https://x.test/r'), 'X');
+
+        // Without the cap: 10_000 then 20_000. With cap: 10_000 then 12_000.
+        $this->assertSame([10_000, 12_000], $this->sleeps);
+    }
+
+    public function test_retry_after_header_capped_at_max_ms(): void
+    {
+        $callCount = 0;
+        Http::fake([
+            'https://x.test/*' => function () use (&$callCount) {
+                $callCount++;
+
+                return $callCount === 1
+                    ? Http::response([], 429, ['Retry-After' => '600']) // 600s = 600_000ms
+                    : Http::response(['ok' => true]);
+            },
+        ]);
+
+        $strategy = $this->strategy(maxAttempts: 2, maxMs: 5_000);
+
+        $strategy->execute($this->send('https://x.test/r'), 'X');
+
+        $this->assertSame([5_000], $this->sleeps, 'Retry-After must respect backoff_max_ms cap.');
+    }
+
+    public function test_from_config_reads_genai_retry(): void
+    {
+        config([
+            'genai.retry' => [
+                'max_attempts' => 7,
+                'backoff_base_ms' => 250,
+                'backoff_max_ms' => 9999,
+            ],
+        ]);
+
+        $strategy = RetryStrategy::fromConfig();
+
+        $this->assertSame(7, $strategy->maxAttempts);
+        $this->assertSame(250, $strategy->backoffBaseMs);
+        $this->assertSame(9999, $strategy->backoffMaxMs);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #7 and #9. Issue #8 (`listModels()` on the interface) was already
delivered in a prior PR — verified during this work, no further changes needed.
Also picks up the two non-blocking follow-ups from PR #6 review (page cap,
style).

## What changed

### Retry layer (#7)

- **`src/Http/RetryStrategy.php`** — single retry path used by all three
  clients. Honors `Retry-After: <seconds>` on 429, falls back to exponential
  backoff (`backoff_base_ms * 2^attempt`, capped at `backoff_max_ms`). Retries
  `429 / 502 / 503 / 504`; never retries `400 / 401 / 403 / 404`.
  `GenAiRateLimitException::$retryAfter` carries the last server-suggested delay
  so callers can re-queue work after the budget is spent.
- **`config/genai.php`** — new `retry.*` keys (`max_attempts`,
  `backoff_base_ms`, `backoff_max_ms`) with env overrides
  (`GENAI_RETRY_MAX_ATTEMPTS`, etc.). `max_attempts = 1` disables retry.
- **All three clients** — collapsed three near-identical 429/4xx/5xx blocks
  into one `$this->retry->execute(fn() => …, 'context')` call. Each
  constructor now accepts an optional `RetryStrategy` for tests / per-call
  override.

### Bedrock auth doc cleanup (#9)

- BedrockClient class docblock no longer references the never-implemented
  `secret_key` config key; clarifies that `api_key` is a Bearer token, not an
  AWS Access Key ID.
- `config/genai.php` — drop `secret_key`/`BEDROCK_SECRET_KEY`; rewrite the
  comment to point out this is bearer-token auth, not SigV4.
- README — env block updated; new blockquote spelling out that this package
  doesn't speak SigV4 and that AWS-SDK-style IAM credentials are not the right
  shape.

### PR #6 follow-ups

- `BedrockClient::listModels()` caps inference-profile pagination at 50 pages
  (defense-in-depth against a misbehaving control plane).
- `$payload = …->json() ?? []` style consistent across both endpoints.

## Test plan

- [x] New `tests/Unit/RetryStrategyTest.php` (12 cases) — covers Retry-After,
  exponential backoff, 5xx retry, 4xx no-retry, max-attempts give-up,
  retryAfter exposure on exception, max-ms cap, `max_attempts = 1` disables
  retry, `fromConfig` reads `genai.retry.*`.
- [x] Sleeps are mocked via injectable `sleeper` closure — suite stays fast.
- [x] Existing `ListModelsTest` updated to import `Response` directly (pint
  ordering); 196 tests pass total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)