### PR TITLE
feat: PricingBook for caller-supplied per-model pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,42 @@ Endpoints used: Anthropic `GET /v1/models`, Bedrock
 not `bedrock-runtime`), Gemini `GET /v1beta/models`. Gemini entries that don't
 support `generateContent` (embeddings, etc.) are filtered out. None of the
 provider catalog APIs currently return pricing, so the cost fields are nullable
-— populate them yourself from your own pricing table if you need cost tracking
-alongside model selection.
+— populate them yourself via `PricingBook` if you need cost tracking alongside
+model selection.
+
+### Pricing table (`PricingBook`)
+
+Supply your own per-million-token prices for any of the three providers
+(`anthropic`, `bedrock`, `gemini`) and the package will both decorate
+`ModelInfo` and turn `Usage` records into dollar costs:
+
+```php
+use Bherila\GenAiLaravel\PricingBook;
+
+$book = PricingBook::fromArray([
+    'anthropic' => [
+        'claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0, 'cache_read' => 0.3, 'cache_creation' => 3.75],
+    ],
+    'bedrock' => [
+        'us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0],
+    ],
+    'gemini' => [
+        'gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4],
+    ],
+]);
+
+// Decorate listModels() output with prices
+$models = $book->enrichAll($client->listModels());
+
+// Compute cost for a specific call
+$cost = $book->estimateCost($response->usage, $client->provider(), $client->model());
+```
+
+`PricingBook::fromConfig()` reads the same shape from the `genai.pricing` config
+key, so application-wide pricing can live alongside provider config. Existing
+non-null cost fields on a `ModelInfo` are preserved by `enrich()`, and
+`estimateCost()` / `priceFor()` return `null` when no price is registered for
+the requested `(provider, modelId)`.
 
 ## File type support
 

--- a/config/genai.php
+++ b/config/genai.php
@@ -24,6 +24,31 @@ return [
         'backoff_max_ms' => (int) env('GENAI_RETRY_BACKOFF_MAX_MS', 30000),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Pricing table (USD per million tokens)
+    |--------------------------------------------------------------------------
+    | No provider catalog API returns pricing, so listModels() always leaves
+    | cost fields null. Populate this table to let PricingBook::fromConfig()
+    | enrich ModelInfo entries and compute costs from Usage.
+    |
+    | Shape: pricing.<provider>.<modelId> => [
+    |     'input' => 3.0, 'output' => 15.0,
+    |     'cache_read' => 0.3, 'cache_creation' => 3.75, // optional
+    | ]
+    */
+    'pricing' => [
+        // 'anthropic' => [
+        //     'claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0],
+        // ],
+        // 'bedrock' => [
+        //     'us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0],
+        // ],
+        // 'gemini' => [
+        //     'gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4],
+        // ],
+    ],
+
     'providers' => [
 
         /*

--- a/src/ModelPrice.php
+++ b/src/ModelPrice.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bherila\GenAiLaravel;
+
+/**
+ * Per-million-token pricing for a single model. Cache prices are optional and
+ * default to the input price when not supplied, matching providers that do not
+ * discount cache reads.
+ */
+final class ModelPrice
+{
+    public function __construct(
+        public readonly float $inputPerMillion,
+        public readonly float $outputPerMillion,
+        public readonly ?float $cacheReadPerMillion = null,
+        public readonly ?float $cacheCreationPerMillion = null,
+    ) {}
+}

--- a/src/PricingBook.php
+++ b/src/PricingBook.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Bherila\GenAiLaravel;
+
+/**
+ * Caller-owned table of model prices, keyed by `(provider, modelId)`.
+ *
+ * No provider catalog API returns pricing today, so `listModels()` always
+ * leaves the cost fields on `ModelInfo` null. PricingBook lets a consuming
+ * application supply its own pricing table (hard-coded, loaded from config,
+ * or fetched out-of-band) and decorate `ModelInfo` results or compute costs
+ * from `Usage` without each call site re-implementing the lookup.
+ */
+final class PricingBook
+{
+    /**
+     * @param  array<string, array<string, ModelPrice>>  $entries  provider => [modelId => ModelPrice]
+     */
+    public function __construct(public readonly array $entries = []) {}
+
+    /**
+     * Build a PricingBook from a config-style array. Each entry under
+     * `genai.pricing.<provider>.<modelId>` is a row with keys
+     * `input`, `output`, optional `cache_read`, optional `cache_creation`.
+     *
+     * @param  array<string, array<string, array{input: float|int, output: float|int, cache_read?: float|int|null, cache_creation?: float|int|null}>>  $config
+     */
+    public static function fromArray(array $config): self
+    {
+        $entries = [];
+        foreach ($config as $provider => $models) {
+            foreach ($models as $modelId => $row) {
+                $entries[$provider][$modelId] = new ModelPrice(
+                    inputPerMillion: (float) $row['input'],
+                    outputPerMillion: (float) $row['output'],
+                    cacheReadPerMillion: isset($row['cache_read']) ? (float) $row['cache_read'] : null,
+                    cacheCreationPerMillion: isset($row['cache_creation']) ? (float) $row['cache_creation'] : null,
+                );
+            }
+        }
+
+        return new self($entries);
+    }
+
+    /**
+     * Read `genai.pricing` from Laravel config and build a PricingBook.
+     */
+    public static function fromConfig(): self
+    {
+        /** @var array<string, array<string, array{input: float|int, output: float|int, cache_read?: float|int|null, cache_creation?: float|int|null}>> $config */
+        $config = (array) config('genai.pricing', []);
+
+        return self::fromArray($config);
+    }
+
+    public function priceFor(string $provider, string $modelId): ?ModelPrice
+    {
+        return $this->entries[$provider][$modelId] ?? null;
+    }
+
+    /**
+     * Return a copy of $model with cost fields populated when a price is known.
+     * Existing non-null cost fields on the input are preserved.
+     */
+    public function enrich(ModelInfo $model): ModelInfo
+    {
+        $price = $this->priceFor($model->provider, $model->id);
+        if ($price === null) {
+            return $model;
+        }
+
+        return new ModelInfo(
+            id: $model->id,
+            name: $model->name,
+            provider: $model->provider,
+            description: $model->description,
+            inputTokenLimit: $model->inputTokenLimit,
+            outputTokenLimit: $model->outputTokenLimit,
+            inputCostPerMillionTokens: $model->inputCostPerMillionTokens ?? $price->inputPerMillion,
+            outputCostPerMillionTokens: $model->outputCostPerMillionTokens ?? $price->outputPerMillion,
+            raw: $model->raw,
+        );
+    }
+
+    /**
+     * @param  list<ModelInfo>  $models
+     * @return list<ModelInfo>
+     */
+    public function enrichAll(array $models): array
+    {
+        return array_map(fn (ModelInfo $m) => $this->enrich($m), $models);
+    }
+
+    /**
+     * Compute USD cost for a Usage record under this book's price for the
+     * given (provider, modelId). Returns null when no price is registered.
+     */
+    public function estimateCost(Usage $usage, string $provider, string $modelId): ?float
+    {
+        $price = $this->priceFor($provider, $modelId);
+        if ($price === null) {
+            return null;
+        }
+
+        return $usage->estimatedCostUsd(
+            inputPerMillion: $price->inputPerMillion,
+            outputPerMillion: $price->outputPerMillion,
+            cacheReadPerMillion: $price->cacheReadPerMillion,
+            cacheCreationPerMillion: $price->cacheCreationPerMillion,
+        );
+    }
+}

--- a/tests/Unit/PricingBookTest.php
+++ b/tests/Unit/PricingBookTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Tests\Unit;
+
+use Bherila\GenAiLaravel\ModelInfo;
+use Bherila\GenAiLaravel\ModelPrice;
+use Bherila\GenAiLaravel\PricingBook;
+use Bherila\GenAiLaravel\Usage;
+use Orchestra\Testbench\TestCase;
+
+class PricingBookTest extends TestCase
+{
+    public function test_from_array_builds_entries_for_all_three_providers(): void
+    {
+        $book = PricingBook::fromArray([
+            'anthropic' => [
+                'claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0, 'cache_read' => 0.3, 'cache_creation' => 3.75],
+            ],
+            'bedrock' => [
+                'us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0],
+            ],
+            'gemini' => [
+                'gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4],
+            ],
+        ]);
+
+        $anthropic = $book->priceFor('anthropic', 'claude-sonnet-4-6');
+        $this->assertInstanceOf(ModelPrice::class, $anthropic);
+        $this->assertSame(3.0, $anthropic->inputPerMillion);
+        $this->assertSame(15.0, $anthropic->outputPerMillion);
+        $this->assertSame(0.3, $anthropic->cacheReadPerMillion);
+        $this->assertSame(3.75, $anthropic->cacheCreationPerMillion);
+
+        $bedrock = $book->priceFor('bedrock', 'us.anthropic.claude-haiku-4-20250514-v1:0');
+        $this->assertSame(0.8, $bedrock->inputPerMillion);
+        $this->assertNull($bedrock->cacheReadPerMillion);
+
+        $gemini = $book->priceFor('gemini', 'gemini-2.0-flash');
+        $this->assertSame(0.1, $gemini->inputPerMillion);
+        $this->assertSame(0.4, $gemini->outputPerMillion);
+    }
+
+    public function test_price_for_returns_null_when_unknown(): void
+    {
+        $book = PricingBook::fromArray([]);
+        $this->assertNull($book->priceFor('anthropic', 'nope'));
+    }
+
+    public function test_enrich_populates_cost_fields_for_each_provider(): void
+    {
+        $book = PricingBook::fromArray([
+            'anthropic' => ['claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0]],
+            'bedrock' => ['us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0]],
+            'gemini' => ['gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4]],
+        ]);
+
+        foreach ([
+            ['anthropic', 'claude-sonnet-4-6', 3.0, 15.0],
+            ['bedrock', 'us.anthropic.claude-haiku-4-20250514-v1:0', 0.8, 4.0],
+            ['gemini', 'gemini-2.0-flash', 0.1, 0.4],
+        ] as [$provider, $id, $in, $out]) {
+            $enriched = $book->enrich(new ModelInfo(id: $id, name: $id, provider: $provider));
+            $this->assertSame($in, $enriched->inputCostPerMillionTokens, "$provider input");
+            $this->assertSame($out, $enriched->outputCostPerMillionTokens, "$provider output");
+        }
+    }
+
+    public function test_enrich_preserves_existing_cost_fields(): void
+    {
+        $book = PricingBook::fromArray([
+            'anthropic' => ['claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0]],
+        ]);
+
+        $enriched = $book->enrich(new ModelInfo(
+            id: 'claude-sonnet-4-6',
+            name: 'Claude',
+            provider: 'anthropic',
+            inputCostPerMillionTokens: 99.0,
+        ));
+
+        $this->assertSame(99.0, $enriched->inputCostPerMillionTokens);
+        $this->assertSame(15.0, $enriched->outputCostPerMillionTokens);
+    }
+
+    public function test_enrich_returns_input_unchanged_when_no_price(): void
+    {
+        $book = PricingBook::fromArray([]);
+        $model = new ModelInfo(id: 'x', name: 'X', provider: 'anthropic');
+        $this->assertSame($model, $book->enrich($model));
+    }
+
+    public function test_enrich_all_maps_list(): void
+    {
+        $book = PricingBook::fromArray([
+            'gemini' => ['gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4]],
+        ]);
+
+        $out = $book->enrichAll([
+            new ModelInfo(id: 'gemini-2.0-flash', name: 'Flash', provider: 'gemini'),
+            new ModelInfo(id: 'unknown', name: 'Unknown', provider: 'gemini'),
+        ]);
+
+        $this->assertSame(0.1, $out[0]->inputCostPerMillionTokens);
+        $this->assertNull($out[1]->inputCostPerMillionTokens);
+    }
+
+    public function test_estimate_cost_uses_price_for_provider_and_model(): void
+    {
+        $book = PricingBook::fromArray([
+            'anthropic' => ['claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0, 'cache_read' => 0.3]],
+        ]);
+
+        $usage = new Usage(inputTokens: 1_000_000, outputTokens: 500_000, totalTokens: 3_500_000, cacheReadInputTokens: 2_000_000);
+
+        // 1M*3 + 0.5M*15 + 2M*0.3 = 3 + 7.5 + 0.6 = 11.1
+        $this->assertSame(11.1, $book->estimateCost($usage, 'anthropic', 'claude-sonnet-4-6'));
+    }
+
+    public function test_estimate_cost_returns_null_when_unknown(): void
+    {
+        $book = PricingBook::fromArray([]);
+        $this->assertNull($book->estimateCost(new Usage(1, 1, 2), 'gemini', 'nope'));
+    }
+
+    public function test_from_config_reads_genai_pricing(): void
+    {
+        config()->set('genai.pricing', [
+            'bedrock' => ['us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0]],
+        ]);
+
+        $book = PricingBook::fromConfig();
+        $price = $book->priceFor('bedrock', 'us.anthropic.claude-haiku-4-20250514-v1:0');
+
+        $this->assertSame(0.8, $price->inputPerMillion);
+        $this->assertSame(4.0, $price->outputPerMillion);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the loose thread from #4: provider catalog APIs don't return
pricing, so `ModelInfo::$inputCostPerMillionTokens` /
`$outputCostPerMillionTokens` are always `null` from `listModels()`.
This PR adds `PricingBook`, a caller-owned table of per-million-token
prices keyed by `(provider, modelId)`, that

- decorates `ModelInfo` results with cost fields,
- turns a `Usage` record into a dollar cost, and
- works uniformly across all three providers (`anthropic`, `bedrock`, `gemini`).

No changes to `GenAiClient` or any client implementation — pricing
stays caller-side, matching the design intent.

## API

```php
use Bherila\GenAiLaravel\PricingBook;

$book = PricingBook::fromArray([
    'anthropic' => ['claude-sonnet-4-6' => ['input' => 3.0, 'output' => 15.0, 'cache_read' => 0.3, 'cache_creation' => 3.75]],
    'bedrock'   => ['us.anthropic.claude-haiku-4-20250514-v1:0' => ['input' => 0.8, 'output' => 4.0]],
    'gemini'    => ['gemini-2.0-flash' => ['input' => 0.1, 'output' => 0.4]],
]);

$models = $book->enrichAll($client->listModels());
$cost   = $book->estimateCost($response->usage, $client->provider(), $client->model());
```

`PricingBook::fromConfig()` reads the same shape from `genai.pricing`,
so application-wide pricing can live in `config/genai.php`. The config
file ships with a commented scaffold showing the shape for each provider.

## What's in this PR

- `src/PricingBook.php` — `priceFor()`, `enrich()`, `enrichAll()`, `estimateCost()`, plus `fromArray()` / `fromConfig()`
- `src/ModelPrice.php` — DTO with optional `cache_read` / `cache_creation`
- `config/genai.php` — `pricing` key with commented all-three-provider scaffold
- `README.md` — new "Pricing table" subsection under listModels
- `tests/Unit/PricingBookTest.php` — 9 cases covering all three providers, preservation of existing cost fields, null handling, config loading, cache pricing in `estimateCost()`

## Test plan

- [x] `vendor/bin/phpunit` — 205 tests, 369 assertions passing
- [x] `vendor/bin/pint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)