### PR TITLE
Add Bedrock HTTP timeout

### DIFF
--- a/config/genai.php
+++ b/config/genai.php
@@ -106,6 +106,9 @@ return [
 
             // Bedrock model ID or inference profile ARN.
             'model' => env('BEDROCK_MODEL', 'us.anthropic.claude-haiku-4-20250514-v1:0'),
+
+            // HTTP timeout in seconds for long-running inference calls.
+            'timeout' => (int) env('BEDROCK_TIMEOUT', 240),
         ],
 
     ],

--- a/src/Clients/BedrockClient.php
+++ b/src/Clients/BedrockClient.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Facades\Http;
  *   session_token  — optional; sent as X-Amz-Security-Token header
  *   region         — AWS region, e.g. "us-east-1" (default: "us-east-1")
  *   model          — model ID, e.g. "us.anthropic.claude-haiku-4-20250514-v1:0"
+ *   timeout        — HTTP timeout in seconds (default: 240)
  */
 class BedrockClient implements GenAiClient
 {
@@ -54,6 +55,7 @@ class BedrockClient implements GenAiClient
         string $region = 'us-east-1',
         string $sessionToken = '',
         ?RetryStrategy $retry = null,
+        int $timeout = 240,
     ) {
         $this->modelId = $modelId;
         $this->region = $region;
@@ -64,7 +66,7 @@ class BedrockClient implements GenAiClient
             $headers['X-Amz-Security-Token'] = $sessionToken;
         }
 
-        $this->http = Http::withToken($apiKey)->withHeaders($headers);
+        $this->http = Http::withToken($apiKey)->withHeaders($headers)->timeout($timeout);
         $this->retry = $retry ?? RetryStrategy::fromConfig();
     }
 
@@ -259,8 +261,8 @@ class BedrockClient implements GenAiClient
         if ($nextToken !== null) {
             throw new GenAiFatalException(
                 'Bedrock inference-profile pagination reached the configured page cap of '
-                . self::MAX_INFERENCE_PROFILE_PAGES
-                . ' before all pages were retrieved; model list may be incomplete.'
+                .self::MAX_INFERENCE_PROFILE_PAGES
+                .' before all pages were retrieved; model list may be incomplete.'
             );
         }
 

--- a/src/Clients/GenAiClientFactory.php
+++ b/src/Clients/GenAiClientFactory.php
@@ -16,7 +16,7 @@ use Bherila\GenAiLaravel\Exceptions\GenAiException;
 class GenAiClientFactory
 {
     /**
-     * @throws GenAiException  When the provider is unknown or misconfigured.
+     * @throws GenAiException When the provider is unknown or misconfigured.
      */
     public static function make(?string $provider = null): GenAiClient
     {
@@ -60,6 +60,7 @@ class GenAiClientFactory
             modelId: $cfg['model'] ?? 'us.anthropic.claude-haiku-4-20250514-v1:0',
             region: $cfg['region'] ?? 'us-east-1',
             sessionToken: $cfg['session_token'] ?? '',
+            timeout: (int) ($cfg['timeout'] ?? 240),
         );
     }
 

--- a/tests/Unit/BedrockClientTest.php
+++ b/tests/Unit/BedrockClientTest.php
@@ -32,9 +32,44 @@ class BedrockClientTest extends TestCase
         $this->assertSame('bedrock', $this->makeClient()->provider());
     }
 
+    public function test_default_http_timeout_supports_long_running_inference(): void
+    {
+        $this->assertSame(240, $this->pendingRequestOptions($this->makeClient())['timeout'] ?? null);
+    }
+
+    public function test_custom_http_timeout_can_be_configured(): void
+    {
+        $client = new BedrockClient(
+            apiKey: 'test-key',
+            modelId: 'us.anthropic.claude-haiku-4-20250514-v1:0',
+            region: 'us-east-1',
+            timeout: 360,
+        );
+
+        $this->assertSame(360, $this->pendingRequestOptions($client)['timeout'] ?? null);
+    }
+
     public function test_max_file_bytes_is_4_5_mb(): void
     {
         $this->assertSame(4_718_592, BedrockClient::maxFileBytes());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pendingRequestOptions(BedrockClient $client): array
+    {
+        $clientReflection = new \ReflectionClass($client);
+        $httpProperty = $clientReflection->getProperty('http');
+        $httpProperty->setAccessible(true);
+        $pendingRequest = $httpProperty->getValue($client);
+
+        $requestReflection = new \ReflectionClass($pendingRequest);
+        $optionsProperty = $requestReflection->getProperty('options');
+        $optionsProperty->setAccessible(true);
+
+        /** @var array<string, mixed> */
+        return $optionsProperty->getValue($pendingRequest);
     }
 
     // ── upload / delete (no-ops) ─────────────────────────────────────────────

--- a/tests/Unit/GenAiClientFactoryTest.php
+++ b/tests/Unit/GenAiClientFactoryTest.php
@@ -26,10 +26,11 @@ class GenAiClientFactoryTest extends TestCase
 
     public function test_makes_bedrock_client_when_default_is_bedrock(): void
     {
-        config(['genai.default' => 'bedrock', 'genai.providers.bedrock.api_key' => 'test-key', 'genai.providers.bedrock.model' => 'model-id']);
+        config(['genai.default' => 'bedrock', 'genai.providers.bedrock.api_key' => 'test-key', 'genai.providers.bedrock.model' => 'model-id', 'genai.providers.bedrock.timeout' => 360]);
         $client = GenAiClientFactory::make();
         $this->assertInstanceOf(BedrockClient::class, $client);
         $this->assertSame('bedrock', $client->provider());
+        $this->assertSame(360, $this->pendingRequestOptions($client)['timeout'] ?? null);
     }
 
     public function test_explicit_provider_overrides_default(): void
@@ -60,5 +61,23 @@ class GenAiClientFactoryTest extends TestCase
         $this->expectException(GenAiException::class);
         $this->expectExceptionMessageMatches('/api_key is not set/');
         GenAiClientFactory::make('bedrock');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pendingRequestOptions(BedrockClient $client): array
+    {
+        $clientReflection = new \ReflectionClass($client);
+        $httpProperty = $clientReflection->getProperty('http');
+        $httpProperty->setAccessible(true);
+        $pendingRequest = $httpProperty->getValue($client);
+
+        $requestReflection = new \ReflectionClass($pendingRequest);
+        $optionsProperty = $requestReflection->getProperty('options');
+        $optionsProperty->setAccessible(true);
+
+        /** @var array<string, mixed> */
+        return $optionsProperty->getValue($pendingRequest);
     }
 }


### PR DESCRIPTION
## Summary

Adds configurable HTTP timeout support to the Bedrock client so long-running Converse calls do not fall back to Laravel's default 30-second HTTP timeout.

## Root Cause

`BedrockClient` created its Laravel HTTP pending request without calling `timeout()`. Longer Bedrock Converse requests could therefore fail with cURL error 28 after 30000ms even when the queue/job timeout allowed more time.

## Changes

- Add a `timeout` constructor argument to `BedrockClient`, defaulting to 240 seconds.
- Apply the timeout to the Bedrock Laravel HTTP client.
- Add `BEDROCK_TIMEOUT` / `genai.providers.bedrock.timeout` config support.
- Pass the configured timeout from `GenAiClientFactory`.
- Cover default and custom Bedrock timeout behavior in unit tests.

## Validation

- `composer test -- --filter='BedrockClientTest|GenAiClientFactoryTest'`
- `vendor/bin/pint --dirty --format agent`
- `php -l src/Clients/BedrockClient.php`
- `php -l src/Clients/GenAiClientFactory.php`