### PR TITLE
Add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.2", "8.3"]
+        php: ["8.2", "8.3", "8.5"]
         laravel: ["12.*", "13.*"]
         exclude:
           - php: "8.2"


### PR DESCRIPTION
## Summary
- add PHP 8.5 to the GitHub Actions test matrix
- keep the existing PHP 8.2 and 8.3 coverage for package compatibility

## Validation
- parsed .github/workflows/tests.yml as YAML
- composer test