### PR TITLE
Add Sentry AI monitoring instrumentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "suggest": {
         "dompdf/dompdf": "Required together with phpoffice/phpword to render DOC / DOCX / ODT / RTF to PDF before sending — preserves formatting and lets providers use their native PDF pipelines (Gemini vision, Anthropic document blocks). Not loaded if absent.",
         "phpoffice/phpspreadsheet": "Enables automatic XLSX / XLS / ODS / CSV → plain-text conversion when sending spreadsheet files to Anthropic or Gemini (^4|^5). Not loaded if absent.",
-        "phpoffice/phpword": "Enables automatic DOC / DOCX / ODT / RTF → PDF conversion (when dompdf/dompdf is also installed) before sending to Anthropic or Gemini. Not loaded if absent."
+        "phpoffice/phpword": "Enables automatic DOC / DOCX / ODT / RTF → PDF conversion (when dompdf/dompdf is also installed) before sending to Anthropic or Gemini. Not loaded if absent.",
+        "sentry/sentry": "Enables optional Sentry AI monitoring instrumentation when using a Sentry PHP SDK version that supports SpanContext::make (^4.23)."
     },
     "autoload": {
         "psr-4": {

--- a/config/genai.php
+++ b/config/genai.php
@@ -117,4 +117,24 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Instrumentation
+    |--------------------------------------------------------------------------
+    |
+    | Sentry instrumentation is optional and activates only when the Sentry PHP
+    | SDK is installed and tracing is enabled for the current transaction.
+    | Prompt/response capture is disabled by default because those values often
+    | contain user or customer data.
+    |
+    */
+    'instrumentation' => [
+        'sentry' => [
+            'enabled' => env('GENAI_SENTRY_INSTRUMENTATION_ENABLED', true),
+            'agent_name' => env('GENAI_AGENT_NAME', env('APP_NAME', 'laravel')),
+            'conversation_id' => env('GENAI_CONVERSATION_ID'),
+            'record_content' => env('GENAI_SENTRY_RECORD_CONTENT', false),
+        ],
+    ],
+
 ];

--- a/src/GenAiRequest.php
+++ b/src/GenAiRequest.php
@@ -3,6 +3,7 @@
 namespace Bherila\GenAiLaravel;
 
 use Bherila\GenAiLaravel\Contracts\GenAiClient;
+use Bherila\GenAiLaravel\Instrumentation\SentryGenAiTracer;
 
 /**
  * Fluent builder for provider-agnostic AI requests.
@@ -38,7 +39,7 @@ final class GenAiRequest
      */
     public static function with(GenAiClient $client): static
     {
-        return new static($client);
+        return new self($client);
     }
 
     /**
@@ -119,7 +120,13 @@ final class GenAiRequest
     public function generate(): GenAiResponse
     {
         $messages = $this->rawMessages ?? $this->buildMessages();
-        $raw = $this->client->converse($this->system, $messages, $this->toolConfig);
+        $raw = SentryGenAiTracer::trace(
+            client: $this->client,
+            inputMessages: $messages,
+            system: $this->system,
+            toolConfig: $this->toolConfig,
+            callback: fn () => $this->client->converse($this->system, $messages, $this->toolConfig),
+        );
 
         return new GenAiResponse(
             text: $this->client->extractText($raw),

--- a/src/Instrumentation/SentryGenAiTracer.php
+++ b/src/Instrumentation/SentryGenAiTracer.php
@@ -54,7 +54,8 @@ final class SentryGenAiTracer
     {
         return self::configBool('genai.instrumentation.sentry.enabled', true)
             && function_exists('\Sentry\trace')
-            && class_exists('\Sentry\Tracing\SpanContext');
+            && class_exists('\Sentry\Tracing\SpanContext')
+            && method_exists(SpanContext::class, 'make');
     }
 
     /** @return array<string, string> */

--- a/src/Instrumentation/SentryGenAiTracer.php
+++ b/src/Instrumentation/SentryGenAiTracer.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Instrumentation;
+
+use Bherila\GenAiLaravel\ContentBlock;
+use Bherila\GenAiLaravel\Contracts\GenAiClient;
+use Bherila\GenAiLaravel\ToolConfig;
+use Sentry\Tracing\SpanContext;
+
+final class SentryGenAiTracer
+{
+    /**
+     * @param  list<array{role: string, content: list<ContentBlock>}>  $inputMessages
+     * @param  callable(): array<string, mixed>  $callback
+     * @return array<string, mixed>
+     */
+    public static function trace(
+        GenAiClient $client,
+        array $inputMessages,
+        string $system,
+        ?ToolConfig $toolConfig,
+        callable $callback,
+    ): array {
+        if (! self::canTrace()) {
+            return $callback();
+        }
+
+        $operation = 'chat';
+        $context = SpanContext::make()
+            ->setOp("gen_ai.{$operation}")
+            ->setDescription("{$operation} ".$client->model())
+            ->setData(self::baseSpanData($client, $operation));
+
+        if (self::recordContent()) {
+            $context->setData(array_merge(
+                $context->getData(),
+                self::contentSpanData($inputMessages, $system, $toolConfig),
+            ));
+        }
+
+        return \Sentry\trace(function ($scope) use ($callback, $client): array {
+            $response = $callback();
+            $span = method_exists($scope, 'getSpan') ? $scope->getSpan() : null;
+
+            if ($span !== null) {
+                $span->setData(self::responseSpanData($client, $response));
+            }
+
+            return $response;
+        }, $context);
+    }
+
+    private static function canTrace(): bool
+    {
+        return self::configBool('genai.instrumentation.sentry.enabled', true)
+            && function_exists('\Sentry\trace')
+            && class_exists('\Sentry\Tracing\SpanContext');
+    }
+
+    /** @return array<string, string> */
+    private static function baseSpanData(GenAiClient $client, string $operation): array
+    {
+        return array_filter([
+            'gen_ai.request.model' => $client->model(),
+            'gen_ai.operation.name' => $operation,
+            'gen_ai.agent.name' => self::configValue('genai.instrumentation.sentry.agent_name'),
+            'gen_ai.conversation.id' => self::configValue('genai.instrumentation.sentry.conversation_id'),
+            'gen_ai.provider.name' => $client->provider(),
+        ], fn ($value) => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param  list<array{role: string, content: list<ContentBlock>}>  $inputMessages
+     * @return array<string, string>
+     */
+    private static function contentSpanData(array $inputMessages, string $system, ?ToolConfig $toolConfig): array
+    {
+        $data = [
+            'gen_ai.input.messages' => json_encode(self::formatMessages($inputMessages), JSON_THROW_ON_ERROR),
+        ];
+
+        if ($system !== '') {
+            $data['gen_ai.system_instructions'] = $system;
+        }
+
+        if ($toolConfig !== null) {
+            $data['gen_ai.tool.definitions'] = json_encode(self::formatTools($toolConfig), JSON_THROW_ON_ERROR);
+        }
+
+        return $data;
+    }
+
+    /** @return array<string, string|int> */
+    private static function responseSpanData(GenAiClient $client, array $response): array
+    {
+        $usage = $client->extractUsage($response);
+        $inputTotal = $usage->inputTokens + $usage->cacheReadInputTokens + $usage->cacheCreationInputTokens;
+        $data = [
+            'gen_ai.usage.input_tokens' => $inputTotal,
+            'gen_ai.usage.output_tokens' => $usage->outputTokens,
+            'gen_ai.usage.total_tokens' => $usage->totalTokens > 0 ? $usage->totalTokens : $inputTotal + $usage->outputTokens,
+        ];
+
+        if ($usage->cacheReadInputTokens > 0) {
+            $data['gen_ai.usage.input_tokens.cached'] = $usage->cacheReadInputTokens;
+        }
+
+        if ($usage->cacheCreationInputTokens > 0) {
+            $data['gen_ai.usage.input_tokens.cache_write'] = $usage->cacheCreationInputTokens;
+        }
+
+        if (self::recordContent()) {
+            $data['gen_ai.output.messages'] = json_encode([
+                [
+                    'role' => 'assistant',
+                    'parts' => [['type' => 'text', 'content' => $client->extractText($response)]],
+                ],
+            ], JSON_THROW_ON_ERROR);
+        }
+
+        return $data;
+    }
+
+    private static function recordContent(): bool
+    {
+        return self::configBool('genai.instrumentation.sentry.record_content', false);
+    }
+
+    private static function configBool(string $key, bool $default): bool
+    {
+        return (bool) self::configValue($key, $default);
+    }
+
+    private static function configValue(string $key, mixed $default = null): mixed
+    {
+        if (! function_exists('config')) {
+            return $default;
+        }
+
+        try {
+            return config($key, $default);
+        } catch (\Throwable) {
+            return $default;
+        }
+    }
+
+    /**
+     * @param  list<array{role: string, content: list<ContentBlock>}>  $messages
+     * @return list<array{role: string, parts: list<array{type: string, content: string}>}>
+     */
+    private static function formatMessages(array $messages): array
+    {
+        return array_map(fn (array $message) => [
+            'role' => $message['role'],
+            'parts' => array_map(fn (ContentBlock $block) => [
+                'type' => $block->type,
+                'content' => $block->type === 'text'
+                    ? (string) $block->text
+                    : '[document: '.($block->mimeType ?? 'application/octet-stream').']',
+            ], $message['content']),
+        ], $messages);
+    }
+
+    /** @return list<array{name: string, description: string, input_schema: array<string, mixed>}> */
+    private static function formatTools(ToolConfig $toolConfig): array
+    {
+        return array_map(fn ($tool) => [
+            'name' => $tool->name,
+            'description' => $tool->description,
+            'input_schema' => $tool->inputSchema->toArray(),
+        ], $toolConfig->tools);
+    }
+}

--- a/tests/Unit/GenAiRequestInstrumentationTest.php
+++ b/tests/Unit/GenAiRequestInstrumentationTest.php
@@ -1,105 +1,117 @@
 <?php
 
-namespace Bherila\GenAiLaravel\Tests\Unit;
-
-use Bherila\GenAiLaravel\ContentBlock;
-use Bherila\GenAiLaravel\Contracts\GenAiClient;
-use Bherila\GenAiLaravel\GenAiRequest;
-use Bherila\GenAiLaravel\ModelInfo;
-use Bherila\GenAiLaravel\ToolConfig;
-use Bherila\GenAiLaravel\Usage;
-use PHPUnit\Framework\TestCase;
-
-class GenAiRequestInstrumentationTest extends TestCase
-{
-    public function test_generate_runs_without_sentry_sdk_installed(): void
+namespace Sentry {
+    function trace(callable $callback, mixed $context): array
     {
-        $client = new class implements GenAiClient
+        throw new \RuntimeException('Unsupported Sentry trace API should not be called.');
+    }
+}
+
+namespace Sentry\Tracing {
+    class SpanContext {}
+}
+
+namespace Bherila\GenAiLaravel\Tests\Unit {
+
+    use Bherila\GenAiLaravel\ContentBlock;
+    use Bherila\GenAiLaravel\Contracts\GenAiClient;
+    use Bherila\GenAiLaravel\GenAiRequest;
+    use Bherila\GenAiLaravel\ModelInfo;
+    use Bherila\GenAiLaravel\ToolConfig;
+    use Bherila\GenAiLaravel\Usage;
+    use PHPUnit\Framework\TestCase;
+
+    class GenAiRequestInstrumentationTest extends TestCase
+    {
+        public function test_generate_runs_with_unsupported_sentry_sdk_api(): void
         {
-            public array $messages = [];
-
-            public function provider(): string
+            $client = new class implements GenAiClient
             {
-                return 'test';
-            }
+                public array $messages = [];
 
-            public function model(): string
-            {
-                return 'test-model';
-            }
+                public function provider(): string
+                {
+                    return 'test';
+                }
 
-            public static function maxFileBytes(): int
-            {
-                return 1024;
-            }
+                public function model(): string
+                {
+                    return 'test-model';
+                }
 
-            public function converse(string $system, array $messages, ?ToolConfig $toolConfig = null): array
-            {
-                $this->messages = $messages;
+                public static function maxFileBytes(): int
+                {
+                    return 1024;
+                }
 
-                return [
-                    'text' => 'ok',
-                    'usage' => [
-                        'input' => 10,
-                        'output' => 4,
-                    ],
-                ];
-            }
+                public function converse(string $system, array $messages, ?ToolConfig $toolConfig = null): array
+                {
+                    $this->messages = $messages;
 
-            public function uploadFile(mixed $fileContent, string $mimeType, string $displayName = ''): ?string
-            {
-                return null;
-            }
+                    return [
+                        'text' => 'ok',
+                        'usage' => [
+                            'input' => 10,
+                            'output' => 4,
+                        ],
+                    ];
+                }
 
-            public function deleteFile(string $fileRef): void {}
+                public function uploadFile(mixed $fileContent, string $mimeType, string $displayName = ''): ?string
+                {
+                    return null;
+                }
 
-            public function converseWithFileRef(string $fileRef, string $mimeType, string $prompt, ?ToolConfig $toolConfig = null): array
-            {
-                return [];
-            }
+                public function deleteFile(string $fileRef): void {}
 
-            public function converseWithInlineFile(string $fileBytes, string $mimeType, string $prompt, string $system = '', ?ToolConfig $toolConfig = null): array
-            {
-                return [];
-            }
+                public function converseWithFileRef(string $fileRef, string $mimeType, string $prompt, ?ToolConfig $toolConfig = null): array
+                {
+                    return [];
+                }
 
-            public function extractText(array $response): string
-            {
-                return (string) ($response['text'] ?? '');
-            }
+                public function converseWithInlineFile(string $fileBytes, string $mimeType, string $prompt, string $system = '', ?ToolConfig $toolConfig = null): array
+                {
+                    return [];
+                }
 
-            public function extractToolCalls(array $response): array
-            {
-                return [];
-            }
+                public function extractText(array $response): string
+                {
+                    return (string) ($response['text'] ?? '');
+                }
 
-            public function checkCredentials(): bool
-            {
-                return true;
-            }
+                public function extractToolCalls(array $response): array
+                {
+                    return [];
+                }
 
-            public function listModels(): array
-            {
-                return [new ModelInfo('test-model', 'Test Model', 'test')];
-            }
+                public function checkCredentials(): bool
+                {
+                    return true;
+                }
 
-            public function extractUsage(array $response): Usage
-            {
-                $usage = $response['usage'] ?? [];
+                public function listModels(): array
+                {
+                    return [new ModelInfo('test-model', 'Test Model', 'test')];
+                }
 
-                return new Usage(
-                    inputTokens: (int) ($usage['input'] ?? 0),
-                    outputTokens: (int) ($usage['output'] ?? 0),
-                    totalTokens: (int) ($usage['input'] ?? 0) + (int) ($usage['output'] ?? 0),
-                );
-            }
-        };
+                public function extractUsage(array $response): Usage
+                {
+                    $usage = $response['usage'] ?? [];
 
-        $response = GenAiRequest::with($client)->prompt('hello')->generate();
+                    return new Usage(
+                        inputTokens: (int) ($usage['input'] ?? 0),
+                        outputTokens: (int) ($usage['output'] ?? 0),
+                        totalTokens: (int) ($usage['input'] ?? 0) + (int) ($usage['output'] ?? 0),
+                    );
+                }
+            };
 
-        $this->assertSame('ok', $response->text);
-        $this->assertSame(10, $response->usage->inputTokens);
-        $this->assertSame('hello', $client->messages[0]['content'][0]->text);
-        $this->assertInstanceOf(ContentBlock::class, $client->messages[0]['content'][0]);
+            $response = GenAiRequest::with($client)->prompt('hello')->generate();
+
+            $this->assertSame('ok', $response->text);
+            $this->assertSame(10, $response->usage->inputTokens);
+            $this->assertSame('hello', $client->messages[0]['content'][0]->text);
+            $this->assertInstanceOf(ContentBlock::class, $client->messages[0]['content'][0]);
+        }
     }
 }

--- a/tests/Unit/GenAiRequestInstrumentationTest.php
+++ b/tests/Unit/GenAiRequestInstrumentationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Bherila\GenAiLaravel\Tests\Unit;
+
+use Bherila\GenAiLaravel\ContentBlock;
+use Bherila\GenAiLaravel\Contracts\GenAiClient;
+use Bherila\GenAiLaravel\GenAiRequest;
+use Bherila\GenAiLaravel\ModelInfo;
+use Bherila\GenAiLaravel\ToolConfig;
+use Bherila\GenAiLaravel\Usage;
+use PHPUnit\Framework\TestCase;
+
+class GenAiRequestInstrumentationTest extends TestCase
+{
+    public function test_generate_runs_without_sentry_sdk_installed(): void
+    {
+        $client = new class implements GenAiClient
+        {
+            public array $messages = [];
+
+            public function provider(): string
+            {
+                return 'test';
+            }
+
+            public function model(): string
+            {
+                return 'test-model';
+            }
+
+            public static function maxFileBytes(): int
+            {
+                return 1024;
+            }
+
+            public function converse(string $system, array $messages, ?ToolConfig $toolConfig = null): array
+            {
+                $this->messages = $messages;
+
+                return [
+                    'text' => 'ok',
+                    'usage' => [
+                        'input' => 10,
+                        'output' => 4,
+                    ],
+                ];
+            }
+
+            public function uploadFile(mixed $fileContent, string $mimeType, string $displayName = ''): ?string
+            {
+                return null;
+            }
+
+            public function deleteFile(string $fileRef): void {}
+
+            public function converseWithFileRef(string $fileRef, string $mimeType, string $prompt, ?ToolConfig $toolConfig = null): array
+            {
+                return [];
+            }
+
+            public function converseWithInlineFile(string $fileBytes, string $mimeType, string $prompt, string $system = '', ?ToolConfig $toolConfig = null): array
+            {
+                return [];
+            }
+
+            public function extractText(array $response): string
+            {
+                return (string) ($response['text'] ?? '');
+            }
+
+            public function extractToolCalls(array $response): array
+            {
+                return [];
+            }
+
+            public function checkCredentials(): bool
+            {
+                return true;
+            }
+
+            public function listModels(): array
+            {
+                return [new ModelInfo('test-model', 'Test Model', 'test')];
+            }
+
+            public function extractUsage(array $response): Usage
+            {
+                $usage = $response['usage'] ?? [];
+
+                return new Usage(
+                    inputTokens: (int) ($usage['input'] ?? 0),
+                    outputTokens: (int) ($usage['output'] ?? 0),
+                    totalTokens: (int) ($usage['input'] ?? 0) + (int) ($usage['output'] ?? 0),
+                );
+            }
+        };
+
+        $response = GenAiRequest::with($client)->prompt('hello')->generate();
+
+        $this->assertSame('ok', $response->text);
+        $this->assertSame(10, $response->usage->inputTokens);
+        $this->assertSame('hello', $client->messages[0]['content'][0]->text);
+        $this->assertInstanceOf(ContentBlock::class, $client->messages[0]['content'][0]);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional Sentry gen_ai span instrumentation around GenAiRequest::generate()
- record model/provider/agent/conversation and token usage attributes using Sentry gen_ai conventions
- keep prompt/output capture opt-in via GENAI_SENTRY_RECORD_CONTENT

## Tests
- composer test
- ./vendor/bin/pint --dirty