### PR TITLE
Use ARM hosted runner for package tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- run the PHP/Laravel compatibility matrix on `ubuntu-24.04-arm`
- preserve the existing matrix and test commands

## Validation
- parsed all workflow YAML
- `git diff --check`
- CI will validate all supported PHP/Laravel combinations on ARM